### PR TITLE
feat(broker): publish_loop 구현 — fan-out 및 죽은 구독자 정리

### DIFF
--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -57,11 +57,32 @@ impl EventBroker {
     /// Returns `Ok(())` on clean shutdown. Returns an error only if
     /// an unexpected internal failure occurs.
     pub async fn publish_loop(
-        self,
-        _rx: mpsc::Receiver<BuildEvent>,
-        _cancel: CancellationToken,
+        mut self,
+        mut rx: mpsc::Receiver<BuildEvent>,
+        cancel: CancellationToken,
     ) -> anyhow::Result<()> {
-        todo!("Read from rx, clone event to each subscriber, remove dead subscribers")
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Ok(()),
+                maybe_event = rx.recv() => {
+                    let event = match maybe_event {
+                        Some(e) => e,
+                        None => return Ok(()),
+                    };
+                    // Fan-out: try_send avoids blocking on slow/full subscribers (R4).
+                    // Full  → drop this event for that subscriber only.
+                    // Closed → permanently remove the subscriber.
+                    self.subscribers.retain(|tx| {
+                        match tx.try_send(event.clone()) {
+                            Ok(()) => true,
+                            Err(mpsc::error::TrySendError::Full(_)) => true,
+                            Err(mpsc::error::TrySendError::Closed(_)) => false,
+                        }
+                    });
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 요약

- cancel 토큰 우선 체크 후 rx.recv()를 tokio::select! biased로 처리
  - try_send fan-out: Full은 해당 이벤트만 드롭(R4 대응), Closed는 retain으로 영구 제거
  - 입력 채널 종료 또는 CancellationToken 발동 시 정상 종료
  
## 변경 유형

- [x] feat: broker : publish_loop 구현 — fan-out 및 죽은 구독자 정리
- [ ] fix: 버그 수정
- [ ] refactor: 기능 변경 없는 코드 개선
- [ ] test: 테스트 추가/수정
- [ ] docs: 문서 변경
- [ ] chore: 빌드, CI, 의존성 등 기타

## 관련 이슈

<!-- closes #123 또는 관련 이슈 번호 -->

## 변경된 모듈

- [ ] `model/` (공용 타입)
- [ ] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [x] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [ ] `main.rs`
- [ ] 문서/CI/설정

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 새 기능에 대한 단위 테스트 추가됨
- [ ] 수동 테스트 완료 (해당 시 설명):

## 리뷰어 참고사항

| before |   after    |                     reason                       |
|----------|--------------|--------------------------------------------------|
| self     | → mut self   |self.subscribers.retain() 이 Vec을 직접 수정하므로     |
| _rx      | → mut rx     |rx.recv().await 의 시그니처가 &mut self 를  요구하므로  |

소유권 이전은 동일, 로컬 바인딩의 가변 여부만 추가
