### PR TITLE
feat(supervisor): implement spawn_build with cancellable line streaming

### DIFF
--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -12,9 +12,13 @@
 //! - `SupervisorHandle::wait()` waits for the child to exit and returns its `ExitStatus`.
 
 use std::path::PathBuf;
-use std::process::ExitStatus;
+use std::process::{ExitStatus, Stdio};
+use std::sync::Mutex;
 
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 /// Spawn a cargo build process and return a stream of JSON lines from its stdout.
 ///
@@ -34,18 +38,120 @@ use tokio::sync::mpsc;
 ///
 /// Returns an error if the cargo process cannot be spawned.
 pub async fn spawn_build(
-    _cargo_args: Vec<String>,
-    _workspace_dir: PathBuf,
+    cargo_args: Vec<String>,
+    workspace_dir: PathBuf,
 ) -> anyhow::Result<(mpsc::Receiver<String>, SupervisorHandle)> {
-    todo!("Spawn `cargo build --message-format=json-render-diagnostics` and stream stdout lines")
+    // Built-in cargo args = "build" plus the JSON output format flag.
+    // User-supplied args are appended after (e.g. "--release", "-p name").
+    let mut args = vec![
+        "build".to_string(),
+        "--message-format=json-render-diagnostics".to_string(),
+    ];
+    args.extend(cargo_args);
+
+    spawn_program("cargo", args, workspace_dir).await
+}
+
+/// Spawn an arbitrary external program and expose its stdout as a stream of lines.
+///
+/// This is the generalised internal helper behind `spawn_build`. Factoring it
+/// out lets unit tests exercise the spawn / stream / cancel paths against a
+/// lightweight command (e.g. `sh -c "..."`) instead of requiring a real cargo
+/// project.
+async fn spawn_program(
+    program: &str,
+    args: Vec<String>,
+    workspace_dir: PathBuf,
+) -> anyhow::Result<(mpsc::Receiver<String>, SupervisorHandle)> {
+    // ── Spawn the child process ─────────────────────────────────────
+    // `tokio::process::Command` is the async wrapper around `std::process::Command`.
+    //   stdout(Stdio::piped()) — pipe the child's stdout so we can read it.
+    //   stderr(Stdio::null())  — drop cargo's "Compiling ..." progress messages,
+    //                            which we don't need. Switch to `piped` if you
+    //                            want to surface them later.
+    //   kill_on_drop(true)     — automatically SIGKILL the child if the `Child`
+    //                            handle is dropped. Defence in depth.
+    let mut child = Command::new(program)
+        .args(&args)
+        .current_dir(&workspace_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    // `child.stdout` is `Option<ChildStdout>`. Take it out and wrap it in a reader.
+    // `None` would mean the `piped()` setting above didn't apply, which would be
+    // a programming error rather than a normal runtime condition.
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("child stdout was not piped"))?;
+
+    // ── Output channel ─────────────────────────────────────────────
+    // One line == one message. Capacity 1024 — when the buffer fills up, the
+    // reader task's `tx.send().await` will park, naturally backpressuring the
+    // child until the consumer catches up.
+    let (tx, rx) = mpsc::channel::<String>(1024);
+
+    // ── Cancellation token ─────────────────────────────────────────
+    // When `SupervisorHandle::cancel()` is called, this token fires and the
+    // reader task exits its loop. The child process itself is killed
+    // separately via `start_kill()` (see `SupervisorHandle::cancel`).
+    let cancel = CancellationToken::new();
+    let cancel_for_reader = cancel.clone();
+
+    // ── stdout reader task ─────────────────────────────────────────
+    // Wrap the pipe in a `BufReader` and use `lines()` to read line by line.
+    //
+    // The loop terminates on any of four conditions:
+    //   1) cancel token fires            → break immediately
+    //   2) lines.next_line() = Ok(None)  → EOF (child closed stdout)
+    //   3) lines.next_line() = Err(_)    → IO error (rare)
+    //   4) tx.send().await = Err         → receiver was dropped (consumer left)
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        loop {
+            tokio::select! {
+                // `biased` polls cancel first every iteration — guarantees
+                // prompt shutdown rather than fairness.
+                biased;
+                _ = cancel_for_reader.cancelled() => break,
+                next = lines.next_line() => {
+                    match next {
+                        Ok(Some(line)) => {
+                            if tx.send(line).await.is_err() {
+                                // Consumer dropped the receiver — no point continuing.
+                                break;
+                            }
+                        }
+                        Ok(None) => break, // EOF
+                        Err(_) => break,   // IO error
+                    }
+                }
+            }
+        }
+        // When this task ends `tx` is dropped, the channel closes, and the
+        // consumer's next `recv()` returns None.
+    });
+
+    let handle = SupervisorHandle {
+        child: Mutex::new(Some(child)),
+        cancel,
+    };
+
+    Ok((rx, handle))
 }
 
 /// Handle for a running cargo build process.
 ///
 /// Allows cancelling the build or waiting for it to complete.
 pub struct SupervisorHandle {
-    // Private fields — will hold the child process handle and cancellation mechanism.
-    _private: (),
+    /// The child process. We use interior mutability (`std::sync::Mutex`)
+    /// because `cancel(&self)` only takes a shared reference. The `Option`
+    /// is here because `wait()` consumes the child via `take()`.
+    child: Mutex<Option<Child>>,
+    /// Token signalling the reader task to stop. Fired by `cancel()`.
+    cancel: CancellationToken,
 }
 
 impl SupervisorHandle {
@@ -53,14 +159,214 @@ impl SupervisorHandle {
     ///
     /// This kills the child process. The associated `Receiver<String>` will
     /// drain any remaining buffered lines and then close.
+    ///
+    /// Idempotent: safe to call multiple times. Subsequent calls are essentially no-ops.
     pub fn cancel(&self) {
-        todo!("Kill the cargo child process")
+        // Signal the reader task — it exits at the next await point.
+        self.cancel.cancel();
+
+        // Send SIGKILL to the child process.
+        // `start_kill` is synchronous (no await needed), so it's safe to call
+        // from `cancel(&self)`. A locking failure here means `wait()` already
+        // took the child out — treat as a no-op.
+        if let Ok(mut guard) = self.child.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.start_kill();
+            }
+        }
     }
 
     /// Wait for the cargo build process to exit.
     ///
-    /// Returns the exit status of the cargo process.
+    /// Returns the exit status of the cargo process. Consumes `self`, so it
+    /// can only be called once.
     pub async fn wait(self) -> anyhow::Result<ExitStatus> {
-        todo!("Wait for the cargo child process to exit")
+        // Take the child out of the mutex. The lock guard must be dropped
+        // immediately so a concurrent `cancel()` call can still acquire the
+        // mutex while we're awaiting the child below.
+        let mut child = {
+            let mut guard = self
+                .child
+                .lock()
+                .map_err(|_| anyhow::anyhow!("child mutex poisoned"))?;
+            guard
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("child already taken"))?
+        };
+        Ok(child.wait().await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests use `sh -c "..."` to spawn lightweight subprocesses instead of
+    //! a real cargo build. The same spawn / stream / cancel logic is
+    //! exercised, but the tests stay fast and deterministic.
+
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Helper: spawn `sh -c <cmd>` with cwd = /tmp.
+    async fn spawn_sh(command: &str) -> anyhow::Result<(mpsc::Receiver<String>, SupervisorHandle)> {
+        spawn_program(
+            "sh",
+            vec!["-c".to_string(), command.to_string()],
+            PathBuf::from("/tmp"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn streams_stdout_lines_in_order() {
+        let (mut rx, handle) = spawn_sh("printf 'line1\\nline2\\nline3\\n'").await.unwrap();
+
+        let l1 = rx.recv().await.unwrap();
+        let l2 = rx.recv().await.unwrap();
+        let l3 = rx.recv().await.unwrap();
+        assert_eq!(l1, "line1");
+        assert_eq!(l2, "line2");
+        assert_eq!(l3, "line3");
+
+        let status = handle.wait().await.unwrap();
+        assert!(status.success(), "exit was {:?}", status);
+    }
+
+    #[tokio::test]
+    async fn channel_closes_when_child_exits() {
+        // After the child closes stdout and exits, the receiver should see None.
+        let (mut rx, handle) = spawn_sh("printf 'only\\n'").await.unwrap();
+        let _ = rx.recv().await.unwrap();
+        let next = timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("recv did not return within 2s");
+        assert!(next.is_none(), "expected channel close, got {:?}", next);
+        let _ = handle.wait().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_kills_long_running_process() {
+        // A 60s sleep — must terminate promptly after cancel.
+        let (_rx, handle) = spawn_sh("sleep 60").await.unwrap();
+
+        handle.cancel();
+
+        let status = timeout(Duration::from_secs(3), handle.wait())
+            .await
+            .expect("wait did not return within 3s after cancel")
+            .unwrap();
+        // Killed by SIGKILL — not a clean exit.
+        assert!(!status.success(), "process should have been killed");
+    }
+
+    #[tokio::test]
+    async fn cancel_is_idempotent() {
+        let (_rx, handle) = spawn_sh("sleep 60").await.unwrap();
+        handle.cancel();
+        handle.cancel(); // second call must not panic
+        let _ = timeout(Duration::from_secs(3), handle.wait()).await;
+    }
+
+    #[tokio::test]
+    async fn missing_program_returns_error() {
+        let result = spawn_program(
+            "this-program-does-not-exist-xyz",
+            vec![],
+            PathBuf::from("/tmp"),
+        )
+        .await;
+        assert!(result.is_err(), "expected spawn to fail");
+    }
+
+    #[tokio::test]
+    async fn dropping_receiver_does_not_panic_reader_task() {
+        // Dropping the receiver immediately must let the reader task exit
+        // cleanly without panicking.
+        let (rx, handle) = spawn_sh("printf 'a\\nb\\nc\\n' && sleep 0.1")
+            .await
+            .unwrap();
+        drop(rx);
+        // Wait briefly for the child to exit. No panics should occur.
+        let _ = timeout(Duration::from_secs(2), handle.wait()).await;
+    }
+
+    /// End-to-end check that real cargo output flows through the supervisor.
+    ///
+    /// Slow (~a few seconds for a hello-world build), so it's `#[ignore]`d
+    /// by default. Run explicitly with:
+    ///
+    /// ```text
+    /// cargo test -- --ignored real_cargo_build
+    /// ```
+    #[tokio::test]
+    #[ignore]
+    async fn real_cargo_build_streams_json_lines() {
+        // 1. Create a tiny hello-world cargo project in a temp directory.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let workspace = dir.path().to_path_buf();
+        std::fs::write(
+            workspace.join("Cargo.toml"),
+            r#"[package]
+name = "demo_chrono"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "demo_chrono"
+path = "src/main.rs"
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(workspace.join("src")).unwrap();
+        std::fs::write(
+            workspace.join("src/main.rs"),
+            "fn main() { println!(\"hi\"); }\n",
+        )
+        .unwrap();
+
+        // 2. Spawn cargo via the supervisor.
+        let (mut rx, handle) = spawn_build(vec![], workspace).await.unwrap();
+
+        // 3. Drain and classify the lines.
+        let mut total = 0usize;
+        let mut compiler_artifact_count = 0usize;
+        let mut build_finished_count = 0usize;
+        let mut first_line: Option<String> = None;
+        while let Some(line) = rx.recv().await {
+            total += 1;
+            if first_line.is_none() {
+                first_line = Some(line.clone());
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                match v.get("reason").and_then(|r| r.as_str()) {
+                    Some("compiler-artifact") => compiler_artifact_count += 1,
+                    Some("build-finished") => build_finished_count += 1,
+                    _ => {}
+                }
+            }
+        }
+
+        let status = handle.wait().await.unwrap();
+        eprintln!(
+            "real cargo build: total={total}, artifact={compiler_artifact_count}, \
+             build_finished={build_finished_count}, exit={:?}",
+            status
+        );
+        if let Some(line) = &first_line {
+            let preview: String = line.chars().take(120).collect();
+            eprintln!("first line: {preview}...");
+        }
+
+        // 4. Assertions.
+        assert!(status.success(), "cargo build failed: {:?}", status);
+        assert!(total > 0, "expected at least one line");
+        assert!(
+            compiler_artifact_count >= 1,
+            "expected at least one compiler-artifact, got {compiler_artifact_count}"
+        );
+        assert_eq!(
+            build_finished_count, 1,
+            "expected exactly one build-finished, got {build_finished_count}"
+        );
     }
 }


### PR DESCRIPTION
## 요약

cargo 자식 프로세스를 띄워 stdout JSON 출력을 한 줄씩 mpsc 채널로 흘려보내는 `spawn_build`를 구현했습니다. tokio task 하나가 백그라운드에서 stdout을 읽고, `SupervisorHandle`로 빌드 도중 cancel 또는 종료 대기가 가능합니다.

## 변경 유형

- [x] feat: 새 기능
- [ ] fix: 버그 수정
- [ ] refactor: 기능 변경 없는 코드 개선
- [x] test: 테스트 추가/수정
- [ ] docs: 문서 변경
- [ ] chore: 빌드, CI, 의존성 등 기타

## 관련 이슈

<!-- 해당 이슈 있으면 여기에. 예: Closes #N -->

## 변경된 모듈

- [ ] `model/` (공용 타입)
- [ ] `cli/`
- [x] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [ ] `main.rs`
- [ ] 문서/CI/설정

## 테스트

- [x] `cargo test` 통과 — supervisor 6/6 (+ 1 ignored: 실제 cargo 통합 테스트)
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo fmt --check` 통과
- [x] 새 기능에 대한 단위 테스트 추가됨 — `sh -c "..."` 기반 6개 시나리오
- [x] 수동 검증: hello-world 임시 cargo 프로젝트로 `spawn_build` 호출, `compiler-artifact` 1개 + `build-finished` 1개 JSON line이 채널로 흘러오는 것 확인

## 리뷰어 참고사항

### 주요 설계 결정

**1. `spawn_build` vs `spawn_program` 분리**

`spawn_build`는 cargo 전용 얇은 wrapper입니다. 실제 spawn / 스트리밍 / 캔슬 로직은 private helper `spawn_program`에 있습니다. 이렇게 분리하니 단위 테스트가 cargo 없이 `sh -c "..."`로 6개 시나리오를 빠르고 결정적으로 검증할 수 있습니다.

**2. `cancel(&self)` vs `wait(self)`의 비대칭**

계약상 `cancel`은 `&self`(여러 위치에서 시그널 가능, 멱등), `wait`은 `self`(한 번만 호출, 결과 반환). 둘 다 만족하려고 child를 `Mutex<Option<Child>>`로 감쌌습니다.
- `cancel`: 락 잡고 `start_kill()` (sync, await 불필요)
- `wait`: 락 잡고 `take()`로 child 꺼낸 뒤 `child.wait().await`

**3. `tokio::select!`의 `biased` 키워드**

reader task가 매 iteration마다 cancel 토큰을 먼저 polling합니다. 자식이 빠르게 출력 중일 때도 cancel 응답성이 보장됩니다.

**4. `kill_on_drop(true)` defense in depth**

사용자가 `cancel`/`wait` 호출 없이 핸들을 drop해도 자식 프로세스가 좀비로 남지 않습니다.

### 테스트 전략

- 6개 unit test (`sh -c` 기반, 빠름):
  - 줄 순서 보장
  - EOF 시 채널 close
  - 장기 실행 프로세스 cancel 즉시 종료
  - cancel 멱등성
  - 실패한 spawn은 에러 반환
  - receiver drop 시 reader task가 panic 없이 종료
- 1개 `#[ignore]` 통합 테스트 (`real_cargo_build_streams_json_lines`):
  - tempdir에 hello-world cargo 프로젝트 생성 후 `spawn_build` 호출
  - `cargo test -- --ignored real_cargo_build`로 실행
  - 실증 결과: `compiler-artifact` 1개 + `build-finished` 1개 JSON line 흐름 확인

### 다음 작업

이 PR + Parser PR이 머지되면 `main.rs`의 `cmd_record` end-to-end smoke가 가능해집니다. (persist 모듈 merge도 필요)