### PR TITLE
feat(tui): implement TUI dashboard — state, render, system monitor, …

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,49 +3,173 @@
 //! Renders a terminal UI showing:
 //! - Currently compiling crates with elapsed time
 //! - Anomaly indicators (slow/fast/normal) per crate
-//! - Overall build progress and ETA
+//! - Overall build progress and crate count
 //! - CPU and memory usage
 //!
 //! # Contract
 //!
-//! - Targets ~60fps rendering via ratatui's event loop.
+//! - Targets ~60 fps rendering via a `tokio::time::interval` tick.
 //! - Restores the terminal to normal mode on `Drop` (raw mode cleanup).
 //! - Exits on `q`, `Ctrl-C`, or when the `CancellationToken` is triggered.
-//! - Consumes `BuildEvent`s from a channel and uses `BuildRepository` for baseline lookups.
+//! - Consumes `BuildEvent`s from a channel and uses `BuildRepository` for
+//!   baseline lookups.
 
 pub mod render;
 pub mod state;
 pub mod system_monitor;
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use crossterm::event::{Event, KeyCode};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+use crate::anomaly;
 use crate::model::BuildEvent;
 use crate::persist::BuildRepository;
+use crate::tui::state::TuiState;
 
-/// Run the TUI dashboard.
+/// Run the TUI dashboard until the build finishes, the user quits, or
+/// `cancel` is triggered.
+///
+/// # Terminal handling
+///
+/// Enables raw mode and enters the alternate screen on start.  A RAII
+/// [`TerminalGuard`] and a custom panic hook together guarantee that the
+/// terminal is restored even if a panic occurs (R11 from CONCURRENCY.md).
 ///
 /// # Arguments
 ///
 /// * `events` — Channel of build events from the broker.
-/// * `repo` — Repository for fetching crate baselines (read-only).
-/// * `cancel` — Cancellation token for graceful shutdown.
-///
-/// # Terminal handling
-///
-/// Enters raw mode and alternate screen on start. On exit (normal or panic),
-/// restores the terminal to its original state.
+/// * `repo`   — Repository for fetching crate baselines (read-only).
+/// * `cancel` — Shared cancellation token for graceful shutdown.
 ///
 /// # Errors
 ///
-/// Returns an error if terminal initialization fails or if an unrecoverable
-/// rendering error occurs.
+/// Returns an error if terminal initialisation fails or if an unrecoverable
+/// rendering error occurs.  Terminal cleanup still runs via the RAII guard
+/// before the error propagates.
 pub async fn run_tui(
-    _events: mpsc::Receiver<BuildEvent>,
-    _repo: Arc<dyn BuildRepository>,
-    _cancel: CancellationToken,
+    mut events: mpsc::Receiver<BuildEvent>,
+    repo: Arc<dyn BuildRepository>,
+    cancel: CancellationToken,
 ) -> anyhow::Result<()> {
-    todo!("Initialize terminal, enter event loop, render frames at ~60fps")
+    // R11: register panic hook so raw mode is restored even on panic.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = crossterm::execute!(
+            std::io::stderr(),
+            crossterm::terminal::LeaveAlternateScreen
+        );
+        original_hook(info);
+    }));
+
+    // R11: RAII guard as a second safety net for normal exit paths.
+    struct TerminalGuard;
+    impl Drop for TerminalGuard {
+        fn drop(&mut self) {
+            let _ = crossterm::terminal::disable_raw_mode();
+            let _ = crossterm::execute!(
+                std::io::stdout(),
+                crossterm::terminal::LeaveAlternateScreen
+            );
+        }
+    }
+    let _guard = TerminalGuard;
+
+    // Initialise terminal.
+    crossterm::terminal::enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut state = TuiState::new();
+
+    // Launch system monitor as a background task.
+    let (sys_tx, mut sys_rx) = mpsc::channel(4);
+    tokio::spawn(system_monitor::run_system_monitor(
+        sys_tx,
+        Duration::from_secs(1),
+        cancel.clone(),
+    ));
+
+    // ~60 fps render tick (16 ms).
+    let mut tick = tokio::time::interval(Duration::from_millis(16));
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+
+            maybe_event = events.recv() => {
+                match maybe_event {
+                    Some(event) => {
+                        let finished_ids = state.apply_event(&event);
+
+                        // For each newly finished crate, look up its baseline
+                        // and classify the duration.
+                        for crate_id in finished_ids {
+                            if let Some(comp) = state.recent.iter().rev().find(|c| c.crate_id == crate_id) {
+                                let duration = comp.duration;
+                                if let Ok(Some(baseline)) = repo.fetch_baseline(&crate_id.name).await {
+                                    let verdict = anomaly::classify(duration, Some(&baseline), 2.0);
+                                    state.set_verdict(&crate_id, verdict);
+                                }
+                            }
+                        }
+
+                        // Final render when the build is complete (R12: render
+                        // before breaking so the user sees the finished state).
+                        if state.is_finished() {
+                            terminal.draw(|f| render::render_dashboard(f, &state))?;
+                            break;
+                        }
+                    }
+                    // Broker closed its channel — build stream ended.
+                    None => break,
+                }
+            },
+
+            Some(snap) = sys_rx.recv() => {
+                state.update_system(snap);
+            },
+
+            _ = tick.tick() => {
+                // Non-blocking keyboard check (crossterm synchronous poll).
+                if crossterm::event::poll(Duration::ZERO)? {
+                    if let Event::Key(key) = crossterm::event::read()? {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Char('Q') => {
+                                cancel.cancel();
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                // Refresh in-progress anomaly verdicts for active crates.
+                let active_ids: Vec<_> = state.active.keys().cloned().collect();
+                for crate_id in active_ids {
+                    if let Some(active) = state.active.get(&crate_id) {
+                        let elapsed = active.elapsed();
+                        if let Ok(Some(baseline)) = repo.fetch_baseline(&crate_id.name).await {
+                            let verdict =
+                                anomaly::classify_in_progress(elapsed, Some(&baseline), 2.0);
+                            state.set_in_progress_verdict(&crate_id, verdict);
+                        }
+                    }
+                }
+
+                terminal.draw(|f| render::render_dashboard(f, &state))?;
+            },
+        }
+    }
+
+    Ok(())
+    // _guard drops here → disable_raw_mode + LeaveAlternateScreen (R11, R12)
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,3 +1,510 @@
 //! TUI rendering logic.
 //!
-//! Builds ratatui widgets from `TuiState` and draws them to the terminal frame.
+//! Builds ratatui widgets from [`TuiState`] and draws them to the terminal
+//! frame.  The main entry point is [`render_dashboard`], called by the event
+//! loop in [`super::run_tui`] on every render tick (~60 fps).
+//!
+//! Layout (top to bottom):
+//! ```text
+//! ┌─ cargo-chrono ────────────────────────────────────────────┐
+//! │ Build #N (release)  •  commit abc1234  •  elapsed 0:28   │
+//! │ 142 crates compiled                                        │
+//! ├─ Active compilations ─────────────────────────────────────┤
+//! │  ▶ serde_derive        12.4s   ⚠ slower                  │
+//! ├─ Recently finished (last 5) ──────────────────────────────┤
+//! │  ✓ syn                  5.8s   · normal                   │
+//! ├─ System   [q] quit  [Ctrl-C] interrupt ───────────────────┤
+//! │  CPU:  75.5%   Memory: 4.0 GiB / 16.0 GiB               │
+//! └───────────────────────────────────────────────────────────┘
+//! ```
+
+use std::time::Duration;
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+use crate::anomaly::AnomalyVerdict;
+use crate::tui::state::TuiState;
+
+/// Render the full dashboard to `frame` from the current `state`.
+///
+/// # Arguments
+///
+/// * `frame` — The ratatui frame to draw into.
+/// * `state` — Current TUI application state snapshot.
+pub fn render_dashboard(frame: &mut Frame, state: &TuiState) {
+    let area = frame.area();
+
+    let chunks = Layout::new(
+        Direction::Vertical,
+        [
+            Constraint::Length(4), // header: build info + crate count
+            Constraint::Min(3),    // active compilations (expands as needed)
+            Constraint::Length(7), // recently finished (5 rows + borders)
+            Constraint::Length(3), // system info + footer hint
+        ],
+    )
+    .split(area);
+
+    render_header(frame, chunks[0], state);
+    render_active(frame, chunks[1], state);
+    render_recent(frame, chunks[2], state);
+    render_system(frame, chunks[3], state);
+}
+
+fn render_header(frame: &mut Frame, area: Rect, state: &TuiState) {
+    let id_str = state
+        .build_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let profile_str = state
+        .profile
+        .as_ref()
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "dev".to_string());
+    let commit_str = state
+        .commit_hash
+        .as_deref()
+        .map(|h| format!("commit {}", &h[..h.len().min(7)]))
+        .unwrap_or_else(|| "no commit".to_string());
+    let elapsed_str = state
+        .elapsed()
+        .map(format_duration)
+        .unwrap_or_else(|| "0:00".to_string());
+
+    let title_line = format!(
+        "Build {} ({})  •  {}  •  elapsed {}",
+        id_str, profile_str, commit_str, elapsed_str
+    );
+
+    let status_line = if state.is_finished() {
+        let symbol = if state.build_result == Some(true) {
+            "✓ Build succeeded"
+        } else {
+            "✗ Build failed"
+        };
+        let total = state
+            .total_duration
+            .map(format_duration)
+            .unwrap_or_default();
+        format!("{}  in {}  ({} crates)", symbol, total, state.finished_count)
+    } else {
+        format!("{} crates compiled", state.finished_count)
+    };
+
+    let text = vec![
+        Line::from(Span::styled(
+            title_line,
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(status_line),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" cargo-chrono ");
+
+    frame.render_widget(Paragraph::new(text).block(block), area);
+}
+
+fn render_active(frame: &mut Frame, area: Rect, state: &TuiState) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    if state.active.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no active compilations)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        // Collect and sort by elapsed descending so the slowest sits at top.
+        let mut entries: Vec<_> = state
+            .active
+            .values()
+            .map(|c| (c, c.elapsed()))
+            .collect();
+        entries.sort_by(|a, b| b.1.cmp(&a.1));
+
+        for (comp, elapsed) in entries {
+            let verdict = verdict_label(comp.verdict);
+            let color = verdict_color(comp.verdict);
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  ▶ {:<32} {:>6}   {}",
+                    comp.crate_id.to_string(),
+                    format_duration(elapsed),
+                    verdict
+                ),
+                Style::default().fg(color),
+            )));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Active compilations ");
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_recent(frame: &mut Frame, area: Rect, state: &TuiState) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    if state.recent.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none yet)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        // Newest first.
+        for comp in state.recent.iter().rev() {
+            let verdict = verdict_label(comp.verdict);
+            let color = verdict_color(comp.verdict);
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  ✓ {:<32} {:>6}   {}",
+                    comp.crate_id.to_string(),
+                    format_duration(comp.duration),
+                    verdict
+                ),
+                Style::default().fg(color),
+            )));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Recently finished (last 5) ");
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_system(frame: &mut Frame, area: Rect, state: &TuiState) {
+    let line = if let Some(snap) = &state.system {
+        format!(
+            "  CPU: {:>5.1}%   Memory: {} / {}",
+            snap.cpu_usage_percent,
+            format_bytes(snap.mem_used_bytes),
+            format_bytes(snap.mem_total_bytes),
+        )
+    } else {
+        "  CPU: --   Memory: --".to_string()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" System   [q] quit  [Ctrl-C] interrupt ");
+
+    frame.render_widget(Paragraph::new(vec![Line::from(line)]).block(block), area);
+}
+
+// ── Public helpers ────────────────────────────────────────────────────────────
+
+/// Format a [`Duration`] as `M:SS` or `H:MM:SS`.
+///
+/// # Returns
+///
+/// `"0:42"` for 42 s, `"1:30"` for 90 s, `"1:01:01"` for 3661 s.
+pub fn format_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{}:{:02}:{:02}", h, m, s)
+    } else {
+        format!("{}:{:02}", m, s)
+    }
+}
+
+/// Format a byte count as a human-readable string.
+///
+/// # Returns
+///
+/// The value in GiB / MiB / KiB / B, rounded to one decimal place.
+pub fn format_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    const KIB: u64 = 1024;
+
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+/// Return a short display label for an [`AnomalyVerdict`].
+///
+/// # Returns
+///
+/// `"⚠ slower"`, `"↓ faster"`, `"· normal"`, or `"? unknown"`.
+pub fn verdict_label(verdict: AnomalyVerdict) -> &'static str {
+    match verdict {
+        AnomalyVerdict::Slower => "⚠ slower",
+        AnomalyVerdict::Faster => "↓ faster",
+        AnomalyVerdict::Normal => "· normal",
+        AnomalyVerdict::Unknown => "? unknown",
+    }
+}
+
+fn verdict_color(verdict: AnomalyVerdict) -> Color {
+    match verdict {
+        AnomalyVerdict::Slower => Color::Red,
+        AnomalyVerdict::Faster => Color::Green,
+        AnomalyVerdict::Normal => Color::Reset,
+        AnomalyVerdict::Unknown => Color::DarkGray,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{BuildEvent, BuildId, BuildProfile, CrateId, CrateKind};
+    use crate::tui::system_monitor::SystemSnapshot;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn make_terminal() -> Terminal<TestBackend> {
+        Terminal::new(TestBackend::new(80, 30)).unwrap()
+    }
+
+    fn buf(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    fn crate_id(name: &str) -> CrateId {
+        CrateId {
+            name: name.to_string(),
+            version: None,
+        }
+    }
+
+    fn started(name: &str) -> BuildEvent {
+        BuildEvent::CompilationStarted {
+            crate_id: crate_id(name),
+            kind: CrateKind::Lib,
+            at: "2025-01-01T00:00:00Z".into(),
+        }
+    }
+
+    fn finished(name: &str, ms: u64) -> BuildEvent {
+        BuildEvent::CompilationFinished {
+            crate_id: crate_id(name),
+            kind: CrateKind::Lib,
+            started_at: "2025-01-01T00:00:00Z".into(),
+            finished_at: "2025-01-01T00:00:01Z".into(),
+            duration: Duration::from_millis(ms),
+        }
+    }
+
+    // ── render_dashboard ─────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_state_does_not_panic() {
+        let mut t = make_terminal();
+        let state = TuiState::new();
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+    }
+
+    #[test]
+    fn header_shows_build_id_when_set() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.set_build_id(BuildId(42));
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("#42"), "expected '#42' in buffer");
+    }
+
+    #[test]
+    fn header_shows_profile_from_build_started() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&BuildEvent::BuildStarted {
+            at: "2025-01-01T00:00:00Z".into(),
+            commit_hash: Some("deadbeef".into()),
+            cargo_args: vec![],
+            profile: BuildProfile::Release,
+        });
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("release"));
+    }
+
+    #[test]
+    fn header_shows_commit_prefix() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&BuildEvent::BuildStarted {
+            at: "2025-01-01T00:00:00Z".into(),
+            commit_hash: Some("abc1234def".into()),
+            cargo_args: vec![],
+            profile: BuildProfile::Dev,
+        });
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        // Only the first 7 chars are shown.
+        assert!(buf(&t).contains("abc1234"));
+    }
+
+    #[test]
+    fn active_section_shows_crate_name() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&started("serde_derive"));
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("serde_derive"));
+    }
+
+    #[test]
+    fn active_section_shows_slower_verdict() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&started("heavy_crate"));
+        state.set_in_progress_verdict(&crate_id("heavy_crate"), AnomalyVerdict::Slower);
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("slower"));
+    }
+
+    #[test]
+    fn recent_section_shows_finished_crate_name() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&started("syn"));
+        state.apply_event(&finished("syn", 1500));
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("syn"));
+    }
+
+    #[test]
+    fn recent_section_shows_faster_verdict() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&started("quote"));
+        state.apply_event(&finished("quote", 200));
+        state.set_verdict(&crate_id("quote"), AnomalyVerdict::Faster);
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("faster"));
+    }
+
+    #[test]
+    fn system_section_shows_cpu_when_snapshot_present() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.update_system(SystemSnapshot {
+            cpu_usage_percent: 75.5,
+            mem_used_bytes: 4 * 1024 * 1024 * 1024,
+            mem_total_bytes: 16 * 1024 * 1024 * 1024,
+        });
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        let text = buf(&t);
+        assert!(text.contains("75.5"), "expected CPU% in buffer");
+        assert!(text.contains("GiB"), "expected GiB in buffer");
+    }
+
+    #[test]
+    fn system_section_shows_placeholder_without_snapshot() {
+        let mut t = make_terminal();
+        let state = TuiState::new();
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("--"));
+    }
+
+    #[test]
+    fn finished_build_shows_success_status() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&BuildEvent::BuildFinished {
+            success: true,
+            total_duration: Duration::from_secs(30),
+            at: "2025-01-01T00:00:30Z".into(),
+        });
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("succeeded"));
+    }
+
+    #[test]
+    fn finished_build_shows_failure_status() {
+        let mut t = make_terminal();
+        let mut state = TuiState::new();
+        state.apply_event(&BuildEvent::BuildFinished {
+            success: false,
+            total_duration: Duration::from_secs(5),
+            at: "2025-01-01T00:00:05Z".into(),
+        });
+        t.draw(|f| render_dashboard(f, &state)).unwrap();
+        assert!(buf(&t).contains("failed"));
+    }
+
+    // ── format_duration ───────────────────────────────────────────────────────
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration(Duration::ZERO), "0:00");
+    }
+
+    #[test]
+    fn format_duration_seconds_only() {
+        assert_eq!(format_duration(Duration::from_secs(42)), "0:42");
+    }
+
+    #[test]
+    fn format_duration_over_one_minute() {
+        assert_eq!(format_duration(Duration::from_secs(90)), "1:30");
+    }
+
+    #[test]
+    fn format_duration_over_one_hour() {
+        assert_eq!(format_duration(Duration::from_secs(3661)), "1:01:01");
+    }
+
+    #[test]
+    fn format_duration_exactly_one_minute() {
+        assert_eq!(format_duration(Duration::from_secs(60)), "1:00");
+    }
+
+    // ── format_bytes ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn format_bytes_below_kib() {
+        assert_eq!(format_bytes(500), "500 B");
+    }
+
+    #[test]
+    fn format_bytes_kib_boundary() {
+        assert_eq!(format_bytes(2048), "2.0 KiB");
+    }
+
+    #[test]
+    fn format_bytes_mib() {
+        assert_eq!(format_bytes(512 * 1024 * 1024), "512.0 MiB");
+    }
+
+    #[test]
+    fn format_bytes_gib() {
+        assert_eq!(format_bytes(4 * 1024 * 1024 * 1024), "4.0 GiB");
+    }
+
+    // ── verdict_label ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn verdict_labels_all_variants() {
+        assert_eq!(verdict_label(AnomalyVerdict::Slower), "⚠ slower");
+        assert_eq!(verdict_label(AnomalyVerdict::Faster), "↓ faster");
+        assert_eq!(verdict_label(AnomalyVerdict::Normal), "· normal");
+        assert_eq!(verdict_label(AnomalyVerdict::Unknown), "? unknown");
+    }
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,4 +1,481 @@
 //! TUI application state.
 //!
-//! Holds all data needed to render the dashboard: active compilations,
-//! completed compilations, anomaly verdicts, build progress, and system metrics.
+//! Holds all data the rendering pass needs to draw the dashboard: active
+//! compilations, recently finished compilations, anomaly verdicts, build
+//! metadata, and system metrics.
+//!
+//! State is mutated from two independent sources:
+//! 1. [`TuiState::apply_event`] — called for each incoming [`BuildEvent`].
+//! 2. [`TuiState::set_verdict`] / [`TuiState::set_in_progress_verdict`] /
+//!    [`TuiState::update_system`] — called when async work (baseline lookups,
+//!    system sampling) completes.
+//!
+//! All mutation is synchronous.  The async event loop in `tui/mod.rs` is
+//! responsible for driving the async side.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use crate::anomaly::AnomalyVerdict;
+use crate::model::{BuildEvent, BuildId, BuildProfile, CrateId, CrateKind};
+use crate::tui::system_monitor::SystemSnapshot;
+
+/// Maximum number of recently-finished compilations kept in the dashboard.
+const MAX_RECENT: usize = 5;
+
+/// A crate that is currently being compiled.
+#[derive(Debug, Clone)]
+pub struct ActiveCompilation {
+    /// The crate being compiled.
+    pub crate_id: CrateId,
+    /// The compilation target kind.
+    pub kind: CrateKind,
+    /// Monotonic clock instant when the compilation started.
+    ///
+    /// Used to compute [`elapsed`](Self::elapsed) for the live timer column.
+    pub started_at: Instant,
+    /// In-progress anomaly classification.
+    ///
+    /// Starts as [`AnomalyVerdict::Unknown`].  Updated periodically by the
+    /// event loop via [`TuiState::set_in_progress_verdict`] using
+    /// [`anomaly::classify_in_progress`](crate::anomaly::classify_in_progress).
+    pub verdict: AnomalyVerdict,
+}
+
+impl ActiveCompilation {
+    /// Returns wall-clock time elapsed since this compilation started.
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+}
+
+/// A crate compilation that has just finished.
+#[derive(Debug, Clone)]
+pub struct FinishedCompilation {
+    /// The crate that finished compiling.
+    pub crate_id: CrateId,
+    /// The compilation target kind.
+    pub kind: CrateKind,
+    /// Total wall-clock compilation duration (from the Parser).
+    pub duration: Duration,
+    /// Anomaly classification against historical baseline.
+    ///
+    /// Starts as [`AnomalyVerdict::Unknown`] and is updated by the event loop
+    /// via [`TuiState::set_verdict`] once the async baseline lookup completes.
+    pub verdict: AnomalyVerdict,
+}
+
+/// All mutable state the TUI rendering pass reads from.
+#[derive(Debug)]
+pub struct TuiState {
+    /// Database-assigned build ID, set once available via [`set_build_id`](Self::set_build_id).
+    pub build_id: Option<BuildId>,
+    /// Build profile (dev / release / custom), set on [`BuildEvent::BuildStarted`].
+    pub profile: Option<BuildProfile>,
+    /// Git commit hash at build time, if the build was inside a git repo.
+    pub commit_hash: Option<String>,
+    /// Monotonic clock instant when the build started.
+    pub started_at: Option<Instant>,
+
+    /// Crates currently being compiled, keyed by [`CrateId`].
+    pub active: HashMap<CrateId, ActiveCompilation>,
+
+    /// Up to [`MAX_RECENT`] most recently finished compilations (oldest first).
+    pub recent: VecDeque<FinishedCompilation>,
+
+    /// Running count of compilations that have finished so far.
+    pub finished_count: usize,
+
+    /// Latest system resource reading, or `None` before the first sample.
+    pub system: Option<SystemSnapshot>,
+
+    /// `None` while the build is running; `Some(success)` after it finishes.
+    pub build_result: Option<bool>,
+    /// Total build duration, populated on [`BuildEvent::BuildFinished`].
+    pub total_duration: Option<Duration>,
+}
+
+impl TuiState {
+    /// Create a fresh, empty state.
+    pub fn new() -> Self {
+        Self {
+            build_id: None,
+            profile: None,
+            commit_hash: None,
+            started_at: None,
+            active: HashMap::new(),
+            recent: VecDeque::new(),
+            finished_count: 0,
+            system: None,
+            build_result: None,
+            total_duration: None,
+        }
+    }
+
+    /// Apply a [`BuildEvent`] to the state, mutating it in place.
+    ///
+    /// # Returns
+    ///
+    /// A list of [`CrateId`]s whose compilations just finished.  The caller
+    /// should use these to schedule async baseline lookups and then call
+    /// [`set_verdict`](Self::set_verdict) with the result.
+    ///
+    /// Returns an empty `Vec` for events that don't finish any compilations.
+    pub fn apply_event(&mut self, event: &BuildEvent) -> Vec<CrateId> {
+        match event {
+            BuildEvent::BuildStarted {
+                commit_hash,
+                profile,
+                ..
+            } => {
+                self.profile = Some(profile.clone());
+                self.commit_hash = commit_hash.clone();
+                self.started_at = Some(Instant::now());
+                vec![]
+            }
+
+            BuildEvent::CompilationStarted { crate_id, kind, .. } => {
+                self.active.insert(
+                    crate_id.clone(),
+                    ActiveCompilation {
+                        crate_id: crate_id.clone(),
+                        kind: kind.clone(),
+                        started_at: Instant::now(),
+                        verdict: AnomalyVerdict::Unknown,
+                    },
+                );
+                vec![]
+            }
+
+            BuildEvent::CompilationFinished {
+                crate_id,
+                kind,
+                duration,
+                ..
+            } => {
+                self.active.remove(crate_id);
+                self.finished_count += 1;
+
+                if self.recent.len() >= MAX_RECENT {
+                    self.recent.pop_front();
+                }
+                self.recent.push_back(FinishedCompilation {
+                    crate_id: crate_id.clone(),
+                    kind: kind.clone(),
+                    duration: *duration,
+                    verdict: AnomalyVerdict::Unknown,
+                });
+
+                vec![crate_id.clone()]
+            }
+
+            BuildEvent::BuildFinished {
+                success,
+                total_duration,
+                ..
+            } => {
+                self.build_result = Some(*success);
+                self.total_duration = Some(*total_duration);
+                self.active.clear();
+                vec![]
+            }
+
+            BuildEvent::CompilerMessage { .. } => vec![],
+        }
+    }
+
+    /// Update the anomaly verdict for a finished compilation.
+    ///
+    /// Matches the most recently pushed entry in `recent` for `crate_id`,
+    /// which is correct because each crate typically compiles once per build.
+    ///
+    /// # Arguments
+    ///
+    /// * `crate_id` — Crate returned earlier by [`apply_event`](Self::apply_event).
+    /// * `verdict`  — Result of [`anomaly::classify`](crate::anomaly::classify).
+    pub fn set_verdict(&mut self, crate_id: &CrateId, verdict: AnomalyVerdict) {
+        if let Some(entry) = self.recent.iter_mut().rev().find(|c| &c.crate_id == crate_id) {
+            entry.verdict = verdict;
+        }
+    }
+
+    /// Update the in-progress anomaly verdict for an active compilation.
+    ///
+    /// Called periodically by the event loop so the dashboard can show
+    /// `⚠ slower` for crates that are already running long.
+    ///
+    /// # Arguments
+    ///
+    /// * `crate_id` — An active crate (still in [`active`](Self::active)).
+    /// * `verdict`  — Result of [`anomaly::classify_in_progress`](crate::anomaly::classify_in_progress).
+    pub fn set_in_progress_verdict(&mut self, crate_id: &CrateId, verdict: AnomalyVerdict) {
+        if let Some(entry) = self.active.get_mut(crate_id) {
+            entry.verdict = verdict;
+        }
+    }
+
+    /// Replace the current system resource snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `snapshot` — A fresh reading from [`SystemMonitor::sample`](super::system_monitor::SystemMonitor::sample).
+    pub fn update_system(&mut self, snapshot: SystemSnapshot) {
+        self.system = Some(snapshot);
+    }
+
+    /// Store the database-assigned [`BuildId`].
+    ///
+    /// The ID is issued by the Persister on `BuildStarted` and is not part of
+    /// the event stream visible to the TUI.  The event loop must pass it in
+    /// via a side channel if real-time display is desired.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` — The build ID assigned by [`BuildRepository::begin_build`](crate::persist::BuildRepository::begin_build).
+    pub fn set_build_id(&mut self, id: BuildId) {
+        self.build_id = Some(id);
+    }
+
+    /// Returns the elapsed time since the build started, or `None` if not started.
+    pub fn elapsed(&self) -> Option<Duration> {
+        self.started_at.map(|t| t.elapsed())
+    }
+
+    /// Returns `true` if the build has finished (success or failure).
+    pub fn is_finished(&self) -> bool {
+        self.build_result.is_some()
+    }
+}
+
+impl Default for TuiState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{BuildProfile, CrateKind};
+    use std::time::Duration;
+
+    fn crate_id(name: &str) -> CrateId {
+        CrateId {
+            name: name.to_string(),
+            version: None,
+        }
+    }
+
+    fn build_started() -> BuildEvent {
+        BuildEvent::BuildStarted {
+            at: "2025-01-01T00:00:00Z".into(),
+            commit_hash: Some("abc123".into()),
+            cargo_args: vec!["build".into()],
+            profile: BuildProfile::Release,
+        }
+    }
+
+    fn compilation_started(name: &str) -> BuildEvent {
+        BuildEvent::CompilationStarted {
+            crate_id: crate_id(name),
+            kind: CrateKind::Lib,
+            at: "2025-01-01T00:00:00Z".into(),
+        }
+    }
+
+    fn compilation_finished(name: &str, ms: u64) -> BuildEvent {
+        BuildEvent::CompilationFinished {
+            crate_id: crate_id(name),
+            kind: CrateKind::Lib,
+            started_at: "2025-01-01T00:00:00Z".into(),
+            finished_at: "2025-01-01T00:00:01Z".into(),
+            duration: Duration::from_millis(ms),
+        }
+    }
+
+    fn build_finished(success: bool) -> BuildEvent {
+        BuildEvent::BuildFinished {
+            success,
+            total_duration: Duration::from_secs(5),
+            at: "2025-01-01T00:00:05Z".into(),
+        }
+    }
+
+    #[test]
+    fn new_state_is_empty() {
+        let s = TuiState::new();
+        assert!(s.build_id.is_none());
+        assert!(s.profile.is_none());
+        assert!(s.active.is_empty());
+        assert!(s.recent.is_empty());
+        assert_eq!(s.finished_count, 0);
+        assert!(s.system.is_none());
+        assert!(!s.is_finished());
+        assert!(s.elapsed().is_none());
+    }
+
+    #[test]
+    fn build_started_sets_metadata() {
+        let mut s = TuiState::new();
+        s.apply_event(&build_started());
+
+        assert_eq!(s.profile, Some(BuildProfile::Release));
+        assert_eq!(s.commit_hash.as_deref(), Some("abc123"));
+        assert!(s.started_at.is_some());
+        assert!(s.elapsed().is_some());
+    }
+
+    #[test]
+    fn compilation_started_adds_to_active() {
+        let mut s = TuiState::new();
+        let finished = s.apply_event(&compilation_started("serde"));
+
+        assert!(finished.is_empty());
+        assert!(s.active.contains_key(&crate_id("serde")));
+        assert_eq!(s.active.len(), 1);
+    }
+
+    #[test]
+    fn compilation_finished_moves_to_recent_and_returns_crate_id() {
+        let mut s = TuiState::new();
+        s.apply_event(&compilation_started("serde"));
+        let finished = s.apply_event(&compilation_finished("serde", 1000));
+
+        assert_eq!(finished, vec![crate_id("serde")]);
+        assert!(s.active.is_empty());
+        assert_eq!(s.recent.len(), 1);
+        assert_eq!(s.recent[0].crate_id, crate_id("serde"));
+        assert_eq!(s.recent[0].duration, Duration::from_millis(1000));
+        assert_eq!(s.finished_count, 1);
+    }
+
+    #[test]
+    fn build_finished_clears_active_and_sets_result() {
+        let mut s = TuiState::new();
+        s.apply_event(&compilation_started("foo"));
+        s.apply_event(&build_finished(true));
+
+        assert!(s.active.is_empty());
+        assert_eq!(s.build_result, Some(true));
+        assert!(s.is_finished());
+        assert_eq!(s.total_duration, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn compiler_message_returns_empty_vec_and_does_not_mutate() {
+        let mut s = TuiState::new();
+        let before_count = s.finished_count;
+        let finished = s.apply_event(&BuildEvent::CompilerMessage {
+            crate_id: crate_id("foo"),
+            level: crate::model::MessageLevel::Warning,
+            text: "unused var".into(),
+        });
+
+        assert!(finished.is_empty());
+        assert_eq!(s.finished_count, before_count);
+    }
+
+    #[test]
+    fn recent_is_capped_at_max() {
+        let mut s = TuiState::new();
+        for i in 0..=MAX_RECENT {
+            let name = format!("crate{}", i);
+            s.apply_event(&compilation_started(&name));
+            s.apply_event(&compilation_finished(&name, 100));
+        }
+
+        assert_eq!(s.recent.len(), MAX_RECENT);
+        // Oldest entry (crate0) should have been evicted.
+        assert!(!s.recent.iter().any(|c| c.crate_id.name == "crate0"));
+    }
+
+    #[test]
+    fn set_verdict_updates_most_recent_match() {
+        let mut s = TuiState::new();
+        s.apply_event(&compilation_started("serde"));
+        s.apply_event(&compilation_finished("serde", 1000));
+
+        s.set_verdict(&crate_id("serde"), AnomalyVerdict::Slower);
+
+        let entry = s.recent.iter().find(|c| c.crate_id.name == "serde").unwrap();
+        assert_eq!(entry.verdict, AnomalyVerdict::Slower);
+    }
+
+    #[test]
+    fn set_verdict_on_unknown_crate_does_not_panic() {
+        let mut s = TuiState::new();
+        s.set_verdict(&crate_id("nonexistent"), AnomalyVerdict::Slower);
+    }
+
+    #[test]
+    fn set_in_progress_verdict_updates_active_entry() {
+        let mut s = TuiState::new();
+        s.apply_event(&compilation_started("tokio"));
+
+        s.set_in_progress_verdict(&crate_id("tokio"), AnomalyVerdict::Slower);
+
+        assert_eq!(s.active[&crate_id("tokio")].verdict, AnomalyVerdict::Slower);
+    }
+
+    #[test]
+    fn set_in_progress_verdict_on_unknown_crate_does_not_panic() {
+        let mut s = TuiState::new();
+        s.set_in_progress_verdict(&crate_id("ghost"), AnomalyVerdict::Normal);
+    }
+
+    #[test]
+    fn update_system_stores_snapshot() {
+        let mut s = TuiState::new();
+        assert!(s.system.is_none());
+
+        let snap = SystemSnapshot {
+            cpu_usage_percent: 42.0,
+            mem_used_bytes: 1024,
+            mem_total_bytes: 8192,
+        };
+        s.update_system(snap);
+
+        let stored = s.system.as_ref().unwrap();
+        assert!((stored.cpu_usage_percent - 42.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn set_build_id_is_stored() {
+        let mut s = TuiState::new();
+        s.set_build_id(BuildId(7));
+        assert_eq!(s.build_id, Some(BuildId(7)));
+    }
+
+    #[test]
+    fn active_compilation_elapsed_is_non_negative() {
+        let mut s = TuiState::new();
+        s.apply_event(&compilation_started("syn"));
+        let elapsed = s.active[&crate_id("syn")].elapsed();
+        assert!(elapsed >= Duration::ZERO);
+    }
+
+    #[test]
+    fn full_build_sequence_state_transitions() {
+        let mut s = TuiState::new();
+
+        s.apply_event(&build_started());
+        assert!(s.started_at.is_some());
+        assert!(!s.is_finished());
+
+        s.apply_event(&compilation_started("proc-macro2"));
+        s.apply_event(&compilation_started("syn"));
+        assert_eq!(s.active.len(), 2);
+
+        s.apply_event(&compilation_finished("proc-macro2", 800));
+        assert_eq!(s.active.len(), 1);
+        assert_eq!(s.finished_count, 1);
+
+        s.apply_event(&compilation_finished("syn", 2000));
+        assert_eq!(s.active.len(), 0);
+        assert_eq!(s.finished_count, 2);
+
+        s.apply_event(&build_finished(true));
+        assert!(s.is_finished());
+        assert_eq!(s.build_result, Some(true));
+    }
+}

--- a/src/tui/system_monitor.rs
+++ b/src/tui/system_monitor.rs
@@ -1,4 +1,208 @@
-//! System resource monitoring.
+//! System resource monitoring for the TUI dashboard.
 //!
-//! Uses `sysinfo` to periodically sample CPU usage and memory consumption
-//! for display in the TUI dashboard.
+//! Periodically samples CPU usage and memory consumption via `sysinfo`
+//! and forwards snapshots to the TUI through a channel.
+//!
+//! All sampling runs inside a dedicated async task so the rendering loop
+//! is never blocked by OS calls.
+
+use std::time::Duration;
+
+use sysinfo::System;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+/// A point-in-time snapshot of system resource usage.
+#[derive(Debug, Clone)]
+pub struct SystemSnapshot {
+    /// Overall CPU usage across all logical cores, in percent (0.0–100.0).
+    pub cpu_usage_percent: f32,
+    /// Physical memory currently in use, in bytes.
+    pub mem_used_bytes: u64,
+    /// Total physical memory available, in bytes.
+    pub mem_total_bytes: u64,
+}
+
+/// Wraps `sysinfo::System` and exposes a single `sample` method.
+///
+/// The internal `System` must be refreshed twice with a brief pause between
+/// calls for `cpu_usage_percent` to reflect real activity; the first call
+/// establishes the baseline.  Callers driving a periodic loop (e.g.
+/// `run_system_monitor`) naturally satisfy this requirement.
+pub struct SystemMonitor {
+    sys: System,
+}
+
+impl SystemMonitor {
+    /// Create a new monitor.
+    ///
+    /// Performs an initial system refresh so that the first call to
+    /// [`sample`](Self::sample) produces a non-zero memory reading.
+    /// CPU usage on the first sample may read 0% because there is no
+    /// prior baseline; subsequent calls will be accurate.
+    pub fn new() -> Self {
+        let mut sys = System::new_all();
+        sys.refresh_all();
+        Self { sys }
+    }
+
+    /// Refresh system data and return a new snapshot.
+    ///
+    /// # Returns
+    ///
+    /// A [`SystemSnapshot`] with the current CPU and memory readings.
+    pub fn sample(&mut self) -> SystemSnapshot {
+        self.sys.refresh_cpu_usage();
+        self.sys.refresh_memory();
+        SystemSnapshot {
+            cpu_usage_percent: self.sys.global_cpu_usage(),
+            mem_used_bytes: self.sys.used_memory(),
+            mem_total_bytes: self.sys.total_memory(),
+        }
+    }
+}
+
+impl Default for SystemMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Run a periodic system-monitoring task.
+///
+/// Samples system resources at `interval` and sends each [`SystemSnapshot`]
+/// to `tx`.  Exits cleanly when:
+/// - `cancel` is triggered, or
+/// - `tx` is closed (the receiver was dropped).
+///
+/// # Arguments
+///
+/// * `tx`       — Channel to forward snapshots to the TUI state.
+/// * `interval` — How often to sample.  Typical value: `Duration::from_secs(1)`.
+/// * `cancel`   — Cancellation token shared with the rest of the application.
+///
+/// # Errors
+///
+/// Returns `Ok(())` on all clean-shutdown paths.  No I/O errors are
+/// expected from `sysinfo` itself; if they occur they are silently ignored.
+pub async fn run_system_monitor(
+    tx: mpsc::Sender<SystemSnapshot>,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    let mut monitor = SystemMonitor::new();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(()),
+            _ = tokio::time::sleep(interval) => {
+                let snapshot = monitor.sample();
+                // If the receiver is gone the TUI has already shut down.
+                if tx.send(snapshot).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn new_does_not_panic() {
+        let _monitor = SystemMonitor::new();
+    }
+
+    #[test]
+    fn sample_returns_valid_ranges() {
+        let mut monitor = SystemMonitor::new();
+        let snap = monitor.sample();
+
+        assert!(
+            snap.cpu_usage_percent >= 0.0 && snap.cpu_usage_percent <= 100.0,
+            "cpu_usage_percent out of range: {}",
+            snap.cpu_usage_percent
+        );
+        assert!(
+            snap.mem_total_bytes > 0,
+            "mem_total_bytes should be non-zero on any real machine"
+        );
+        assert!(
+            snap.mem_used_bytes <= snap.mem_total_bytes,
+            "used ({}) > total ({})",
+            snap.mem_used_bytes,
+            snap.mem_total_bytes
+        );
+    }
+
+    #[test]
+    fn consecutive_samples_do_not_panic() {
+        let mut monitor = SystemMonitor::new();
+        for _ in 0..3 {
+            let _ = monitor.sample();
+        }
+    }
+
+    #[tokio::test]
+    async fn run_exits_on_cancel() {
+        let (tx, _rx) = mpsc::channel(4);
+        let cancel = CancellationToken::new();
+
+        let handle = tokio::spawn(run_system_monitor(
+            tx,
+            Duration::from_secs(60), // long interval — won't fire
+            cancel.clone(),
+        ));
+
+        cancel.cancel();
+
+        let result = timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("run_system_monitor did not exit after cancel");
+        result.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_exits_when_receiver_dropped() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx); // close the receiver immediately
+        let cancel = CancellationToken::new();
+
+        let handle = tokio::spawn(run_system_monitor(
+            tx,
+            Duration::from_millis(10), // short so the send fires quickly
+            cancel,
+        ));
+
+        let result = timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("run_system_monitor did not exit after receiver drop");
+        result.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_sends_snapshots_to_channel() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let cancel = CancellationToken::new();
+
+        tokio::spawn(run_system_monitor(
+            tx,
+            Duration::from_millis(50),
+            cancel.clone(),
+        ));
+
+        let snap = timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timed out waiting for first snapshot")
+            .expect("channel closed before first snapshot");
+
+        assert!(snap.mem_total_bytes > 0);
+        cancel.cancel();
+    }
+}


### PR DESCRIPTION
## 요약

  - tui/system_monitor: SystemMonitor + run_system_monitor via sysinfo crate
  - tui/state: TuiState with apply_event, set_verdict, set_in_progress_verdict
  - tui/render: render_dashboard with 4-section layout, format helpers, verdict_label
  - tui/mod.rs: run_tui with TerminalGuard RAII + panic hook (R11), 60fps select! loop
  - 43 unit tests added (system_monitor×6, state×15, render×22).

## 변경 유형

- [x] feat: 새 기능
- [ ] fix: 버그 수정
- [ ] refactor: 기능 변경 없는 코드 개선
- [x] test: 테스트 추가/수정
- [ ] docs: 문서 변경
- [ ] chore: 빌드, CI, 의존성 등 기타


## 변경된 모듈

- [ ] `model/` (공용 타입)
- [ ] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [x] `tui/`
- [ ] `main.rs`
- [ ] 문서/CI/설정

## 테스트

- [ ] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 새 기능에 대한 단위 테스트 추가됨
- [ ] 수동 테스트 완료 (해당 시 설명):

## 리뷰어 참고사항

일부 단위테스트에 경우 broker 병합 후 해소
