### PR TITLE
fix(main,persist): discard interrupted builds (#9)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn cmd_record(
     cargo_args: Vec<String>,
     workspace_dir: PathBuf,
     db_path: &std::path::Path,
-    _cancel: CancellationToken,
+    cancel: CancellationToken,
 ) -> anyhow::Result<()> {
     let commit_hash = read_git_head();
     let profile = infer_profile(&cargo_args);
@@ -91,10 +91,8 @@ async fn cmd_record(
     };
     let event_rx = parser::run_parser(line_rx, config).await?;
 
-    let build_id = persist::run_persister(repo, event_rx).await?;
-    println!("Build {} recorded.", build_id);
-
-    Ok(())
+    let build_id = persist::run_persister(repo.clone(), event_rx).await?;
+    finalize_or_discard(repo, build_id, &cancel).await
 }
 
 /// Watch a build: Supervisor → Parser → Broker → (Persister + TUI) fan-out.
@@ -130,12 +128,31 @@ async fn cmd_watch(
     let (broker_result, persister_result, tui_result) = tokio::try_join!(
         event_broker.publish_loop(event_rx, cancel.clone()),
         persist::run_persister(repo_clone, persister_rx),
-        tui::run_tui(tui_rx, repo, cancel_clone),
+        tui::run_tui(tui_rx, repo.clone(), cancel_clone),
     )?;
 
     let _ = (broker_result, tui_result);
-    println!("Build {} recorded.", persister_result);
+    finalize_or_discard(repo, persister_result, &cancel).await
+}
 
+/// Either announce the recorded build, or — if the user cancelled — delete the
+/// partial DB rows so they don't pollute baselines and clutter `chrono ls`.
+///
+/// "Cancelled" is detected via the shared `CancellationToken`, which is fired
+/// by the Ctrl-C signal handler in `main()` and by the TUI on `q` / Ctrl-C.
+/// Real cargo failures (compile errors that exit non-zero on their own) keep
+/// the build record so the user can still inspect what happened.
+async fn finalize_or_discard(
+    repo: Arc<dyn BuildRepository>,
+    build_id: BuildId,
+    cancel: &CancellationToken,
+) -> anyhow::Result<()> {
+    if cancel.is_cancelled() {
+        repo.delete_build(build_id).await?;
+        eprintln!("Build interrupted — not recorded.");
+    } else {
+        println!("Build {} recorded.", build_id);
+    }
     Ok(())
 }
 

--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -81,6 +81,15 @@ pub trait BuildRepository: Send + Sync {
     /// Computes mean, standard deviation, min, and max from historical compilation times.
     /// Returns `None` if there is insufficient data.
     async fn fetch_baseline(&self, crate_name: &str) -> anyhow::Result<Option<Baseline>>;
+
+    /// Delete a build and all of its crate compilations.
+    ///
+    /// Used by the orchestrator to discard a build that the user interrupted
+    /// (Ctrl-C / `q`). Deleting cancelled builds keeps anomaly baselines from
+    /// being polluted by partial timing data.
+    ///
+    /// Idempotent: deleting a non-existent build is not an error.
+    async fn delete_build(&self, id: BuildId) -> anyhow::Result<()>;
 }
 
 /// Consume a `BuildEvent` stream and persist each event to the repository.

--- a/src/persist/sqlite.rs
+++ b/src/persist/sqlite.rs
@@ -116,6 +116,17 @@ impl BuildRepository for SqliteRepository {
         Ok(())
     }
 
+    async fn delete_build(&self, id: BuildId) -> anyhow::Result<()> {
+        let mut conn = self.conn.lock().await;
+        // Atomic: drop the build's crate_compilations and the build row in
+        // one transaction so we never end up with orphaned rows.
+        let tx = conn.transaction()?;
+        tx.execute("DELETE FROM crate_compilations WHERE build_id = ?1", [id.0])?;
+        tx.execute("DELETE FROM builds WHERE id = ?1", [id.0])?;
+        tx.commit()?;
+        Ok(())
+    }
+
     async fn list_builds(&self, limit: usize) -> anyhow::Result<Vec<Build>> {
         let conn = self.conn.lock().await;
 
@@ -401,6 +412,42 @@ mod tests {
         let (_d, repo) = fresh_repo().await;
         let builds = repo.list_builds(10).await.unwrap();
         assert!(builds.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_build_removes_build_and_compilations() {
+        let (_d, repo) = fresh_repo().await;
+        let id = repo
+            .begin_build("2025-01-01T00:00:00Z", None, "[]", &BuildProfile::Dev)
+            .await
+            .unwrap();
+        repo.record_compilation(
+            id,
+            &lib_crate("foo"),
+            "lib",
+            "2025-01-01T00:00:00Z",
+            "2025-01-01T00:00:01Z",
+            Duration::from_millis(100),
+        )
+        .await
+        .unwrap();
+        repo.finalize_build(id, "2025-01-01T00:00:01Z", true, Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        repo.delete_build(id).await.unwrap();
+
+        // Build is gone.
+        assert!(repo.fetch_build(id).await.unwrap().is_none());
+        // Baseline can no longer find the deleted compilation.
+        assert!(repo.fetch_baseline("foo").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_build_is_idempotent_on_missing_id() {
+        let (_d, repo) = fresh_repo().await;
+        // Deleting a never-inserted id must not error.
+        repo.delete_build(BuildId(9999)).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 요약

사용자가 Ctrl-C 또는 q로 중단한 빌드를 DB에 기록하지 않도록 수정. 진짜 cargo 컴파일 에러는 그대로 기록되어 검토 가능.

## 변경 유형

- [x] feat: 새 기능 (`BuildRepository::delete_build`)
- [x] fix: 버그 수정 (cancel 시 부분 데이터 폐기)

## 관련 이슈

Closes #9

## 변경된 모듈

- [x] `persist/` (trait 확장 + SQLite 구현)
- [x] `main.rs` (cancel 감지 후 delete_build 호출)

## 테스트

- [x] `cargo test` 통과 (127개)
- [x] `cargo clippy -- -D warnings` 통과
- [x] 새 기능에 대한 단위 테스트 추가됨 (`delete_build_removes_build_and_compilations`, `delete_build_is_idempotent_on_missing_id`)
- [ ] 수동 테스트: 별도 Rust 프로젝트에서 \`record\` 도중 Ctrl-C → \`Build interrupted — not recorded.\` 출력 + \`ls\`에 안 보이는지 확인 필요

## 리뷰어 참고사항

**구현 분리:**
- 첫 커밋(`feat(persist)`): trait + SqliteRepository 구현 + 단위 테스트 — Data 모듈 변경
- 두 번째 커밋(`fix(main)`): orchestration에서 cancel 감지 후 delete 호출 — Integrator 모듈 변경

**구분 기준:**
| 종료 이유 | 감지 | 기록? |
|---|---|---|
| 정상 빌드 성공 | exit 0 | ✅ |
| 진짜 컴파일 에러 | exit ≠ 0, cancel 미발생 | ✅ |
| 사용자 Ctrl-C / q | \`cancel.is_cancelled() == true\` | ❌ |
| OOM / 외부 SIGKILL | exit by signal, cancel 미발생 | 회색지대 — 1차로 ❌가 안 됨 (현재는 ✅로 기록됨) |

**향후 확장 여지:**
- \`--keep-cancelled\` 플래그로 부분 데이터를 보존하고 싶은 사용자에게 옵션 제공 가능
- 외부 SIGKILL 케이스 처리 — 현재는 cancel 토큰만 보고 판단하므로 외부에서 죽은 경우는 여전히 FAIL로 기록됨

**스키마:**
\`crate_compilations.build_id\`에 ON DELETE CASCADE가 없어 SQLite 트랜잭션 안에서 \`crate_compilations\` → \`builds\` 순서로 직접 DELETE.