### PR TITLE
fix(persist): make concurrent DB access safe (#3)

### DIFF
--- a/src/persist/migrations.rs
+++ b/src/persist/migrations.rs
@@ -2,8 +2,20 @@
 //!
 //! Contains the SQL DDL for creating the cargo-chrono tables and indices.
 //! Called by `SqliteRepository::open()` on first use.
+//!
+//! # Concurrency
+//!
+//! Migrations run inside a `BEGIN IMMEDIATE` transaction so a second
+//! `cargo-chrono` process opening the same DB file blocks until the first
+//! finishes (or times out). The current `PRAGMA user_version` is checked
+//! inside the transaction; if it already matches `SCHEMA_VERSION`, the
+//! migration is a no-op. This keeps the open path safe against the race in
+//! issue #3.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, TransactionBehavior};
+
+/// Bumped whenever the schema changes. Stored in `PRAGMA user_version`.
+const SCHEMA_VERSION: i32 = 1;
 
 /// SQL statements for the initial schema (version 1).
 const SCHEMA_V1: &str = r#"
@@ -41,13 +53,53 @@ CREATE INDEX IF NOT EXISTS idx_builds_started
 
 /// Run all pending migrations on the given database connection.
 ///
-/// Currently only applies the V1 schema. Future versions will add
-/// a `schema_version` table and incremental migrations.
+/// Atomic: opens an `IMMEDIATE` transaction so concurrent openers serialise
+/// on the writer lock, and uses `PRAGMA user_version` to skip work that has
+/// already been applied. Idempotent.
 ///
 /// # Errors
 ///
-/// Returns an error if any SQL statement fails to execute.
-pub(crate) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute_batch(SCHEMA_V1)?;
+/// Returns an error if any SQL statement fails to execute or if the writer
+/// lock cannot be acquired within the connection's `busy_timeout`.
+pub(crate) fn run_migrations(conn: &mut Connection) -> anyhow::Result<()> {
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+    let current: i32 = tx.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if current >= SCHEMA_VERSION {
+        // Another process already migrated this DB. Nothing to do.
+        return Ok(());
+    }
+
+    tx.execute_batch(SCHEMA_V1)?;
+    // PRAGMA does not accept bound parameters, so format the version in.
+    tx.execute_batch(&format!("PRAGMA user_version = {}", SCHEMA_VERSION))?;
+    tx.commit()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_run_sets_user_version() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn).unwrap();
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn second_run_is_a_noop() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_migrations(&mut conn).unwrap();
+        // Second call must not error and must leave user_version unchanged.
+        run_migrations(&mut conn).unwrap();
+        let v: i32 = conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION);
+    }
 }

--- a/src/persist/sqlite.rs
+++ b/src/persist/sqlite.rs
@@ -26,20 +26,27 @@ pub struct SqliteRepository {
 impl SqliteRepository {
     /// Open (or create) a SQLite database at the given path.
     ///
-    /// Enables WAL journal mode for better concurrent read performance
-    /// and runs any pending schema migrations.
+    /// - Sets a 5s `busy_timeout` so writer-lock contention from another
+    ///   `cargo-chrono` process retries automatically instead of failing
+    ///   with `SQLITE_BUSY`.
+    /// - Enables WAL journal mode for better concurrent read performance.
+    /// - Runs any pending schema migrations atomically (see
+    ///   [`migrations::run_migrations`]).
     ///
     /// # Errors
     ///
     /// Returns an error if the database cannot be opened or if migrations fail.
     pub async fn open(path: &Path) -> anyhow::Result<Self> {
-        let conn = Connection::open(path)?;
+        let mut conn = Connection::open(path)?;
+
+        // Block (rather than instantly failing) on writer-lock contention.
+        conn.busy_timeout(Duration::from_secs(5))?;
 
         // Enable WAL mode for better concurrent read performance.
         conn.pragma_update(None, "journal_mode", "wal")?;
 
-        // Run schema migrations.
-        migrations::run_migrations(&conn)?;
+        // Run schema migrations atomically (handles concurrent openers).
+        migrations::run_migrations(&mut conn)?;
 
         Ok(Self {
             conn: Mutex::new(conn),
@@ -273,6 +280,60 @@ mod tests {
             name: name.to_string(),
             version: None,
         }
+    }
+
+    /// Two separate SqliteRepository handles on the same DB file must be able
+    /// to open and write concurrently without surfacing SQLITE_BUSY. Reproduces
+    /// the open-time race documented in issue #3.
+    #[tokio::test]
+    async fn concurrent_open_and_write_from_two_tasks() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("concurrent.db");
+        let p1 = db_path.clone();
+        let p2 = db_path.clone();
+
+        let writer = |path: std::path::PathBuf, label: &'static str| async move {
+            let repo = SqliteRepository::open(&path).await.unwrap();
+            for i in 0..10 {
+                let id = repo
+                    .begin_build(
+                        &format!("2025-01-01T00:00:{:02}Z", i),
+                        None,
+                        "[]",
+                        &BuildProfile::Dev,
+                    )
+                    .await
+                    .unwrap_or_else(|e| panic!("{label} begin_build failed: {e}"));
+                repo.record_compilation(
+                    id,
+                    &lib_crate(label),
+                    "lib",
+                    "2025-01-01T00:00:00Z",
+                    "2025-01-01T00:00:01Z",
+                    Duration::from_millis(100),
+                )
+                .await
+                .unwrap_or_else(|e| panic!("{label} record_compilation failed: {e}"));
+                repo.finalize_build(id, "2025-01-01T00:00:01Z", true, Duration::from_secs(1))
+                    .await
+                    .unwrap_or_else(|e| panic!("{label} finalize_build failed: {e}"));
+            }
+        };
+
+        let h1 = tokio::spawn(writer(p1, "task-a"));
+        let h2 = tokio::spawn(writer(p2, "task-b"));
+        h1.await.unwrap();
+        h2.await.unwrap();
+
+        // Final repo to verify the DB is intact.
+        let repo = SqliteRepository::open(&db_path).await.unwrap();
+        let builds = repo.list_builds(100).await.unwrap();
+        assert_eq!(
+            builds.len(),
+            20,
+            "expected 10 + 10 builds, got {}",
+            builds.len()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 요약

같은 `.cargo-chrono/history.db`를 여러 `cargo-chrono` 프로세스가 동시에 열어도 안전하도록 수정. SQLITE_BUSY로 무작위 실패하던 문제와 마이그레이션 race를 해결.

## 변경 유형

- [x] fix: 버그 수정

## 관련 이슈

Closes #3

## 변경된 모듈

- [x] `persist/` (Data 소유 — `SqliteRepository::open`, `migrations::run_migrations`)

## 테스트

- [x] `cargo test` 통과 (128개)
- [x] `cargo clippy -- -D warnings` 통과
- [x] 새 단위/통합 테스트 추가:
  - `migrations::tests::first_run_sets_user_version`
  - `migrations::tests::second_run_is_a_noop`
  - `sqlite::tests::concurrent_open_and_write_from_two_tasks` — 두 tokio task가 같은 DB 파일을 별도 `SqliteRepository`로 열고 각각 10개 빌드를 INSERT, 총 20개가 모두 살아남는지 검증
- [ ] 수동 테스트: 두 터미널에서 `cargo-chrono record`를 동시에 돌려 SQLITE_BUSY 없이 성공하는지 확인 필요

## 리뷰어 참고사항

**커밋 분리:**
- `067a631 fix(persist): set 5s busy_timeout on connection open` — `Connection::busy_timeout(5s)` 추가. 동시성 통합 테스트(`concurrent_open_and_write_from_two_tasks`)도 이 커밋에 포함 — busy_timeout이 없으면 곧장 fail이라 이 커밋 단독으로 검증 가능.
- `a98060f fix(persist): run migrations atomically with user_version guard` — `BEGIN IMMEDIATE` 트랜잭션 + `PRAGMA user_version` 가드. 두 프로세스가 동시에 open()을 호출해도 한 번만 적용.

**구현 결정:**

| 항목 | 결정 | 이유 |
|---|---|---|
| busy_timeout 값 | 5초 | 이슈에 명시된 권장값. 빌드 한 단위 INSERT가 ms급이라 5초면 충분히 여유 |
| 트랜잭션 모드 | `IMMEDIATE` | DEFERRED는 첫 write 시점에 락을 잡아 race가 남음. IMMEDIATE는 즉시 writer 락 |
| user_version 비교 | `>= SCHEMA_VERSION`이면 no-op | 향후 다운그레이드 케이스에서도 안전 |
| 테스트 위치 | `src/persist/sqlite.rs`의 `#[cfg(test)] mod tests` | 프로젝트 전체가 동일 패턴 (별도 `tests/` 디렉터리는 fixture 전용). lib 타겟이 없어 integration test 디렉터리는 부적합 |

**동작 검증:**

새 테스트 `concurrent_open_and_write_from_two_tasks`는:
1. 두 task가 같은 `concurrent.db`를 각자 `SqliteRepository::open` 으로 연다.
2. 각 task가 10번씩 `begin_build` → `record_compilation` → `finalize_build` 사이클을 돈다.
3. 마지막에 새 repo로 다시 열어서 `list_builds(100)`이 정확히 20개를 돌려주는지 확인.

busy_timeout 없이 돌리면 SQLITE_BUSY로 즉시 panic. busy_timeout이 있으면 락이 풀릴 때까지 자동 대기해 모두 성공.

**향후 확장:**
- 스키마 변경 시 `SCHEMA_VERSION` 상수를 올리고 새 `SCHEMA_V2` 추가, `current` 값에 따라 분기. 현재는 v1뿐이라 단순 비교만.