### PR TITLE
chore: add crates.io release workflow (Option A)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+# Triggered by pushing a tag like `v0.1.0`. The tag's version *must* match
+# the `version` field in `Cargo.toml`; the workflow fails fast otherwise.
+#
+# Required repository secret:
+#   CARGO_REGISTRY_TOKEN — crates.io API token
+#                          (create at https://crates.io/me, scope: publish-update)
+#
+# Cutting a release:
+#   1. Bump `version` in Cargo.toml on main.
+#   2. git tag v$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+#   3. git push origin --tags
+#   4. Watch this workflow on the Actions tab.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          version="$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Tag v$tag does not match Cargo.toml version $version"
+            exit 1
+          fi
+          echo "Releasing v$version"
+
+      - name: Run tests
+        run: cargo test --all-targets
+
+      - name: Package check (cargo publish --dry-run)
+        run: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"
 readme = "README.md"
+repository = "https://github.com/ymw0407/cargo-chrono"
+homepage = "https://github.com/ymw0407/cargo-chrono"
 keywords = ["cargo", "build", "performance", "profiling"]
 categories = ["development-tools::profiling", "command-line-utilities"]
 


### PR DESCRIPTION
## 요약

태그 푸시(\`v*\`)에 자동 \`cargo publish\` 하는 release.yml 추가. crates.io 단일 채널만 사용하는 minimum-viable 배포 CD.

## 변경 유형

- [x] chore: CI/배포 설정

## 변경 내역

**1. \`.github/workflows/release.yml\` 신규 (~55줄)**
- 트리거: \`push\` to \`v*\` 태그
- 단계:
  1. 태그 \`vX.Y.Z\`가 \`Cargo.toml\`의 \`version\`과 일치하는지 검증 (불일치 시 즉시 fail)
  2. \`cargo test --all-targets\` — 회귀 검증
  3. \`cargo publish --dry-run\` — 패키징/메타데이터 검증
  4. \`cargo publish\` — \`CARGO_REGISTRY_TOKEN\` secret 사용
- 릴리스 절차는 워크플로 상단 주석에 명시

**2. \`Cargo.toml\` 보강**
- \`repository = \"https://github.com/ymw0407/cargo-chrono\"\` 추가
- \`homepage = \"https://github.com/ymw0407/cargo-chrono\"\` 추가
- crates.io 페이지에서 GitHub 링크 노출

## ⚠️ 머지 후 사용자 액션 필요

**1. crates.io 토큰 발급 + GitHub Secrets 등록**

\`\`\`
crates.io → Account Settings → API Tokens → \"New Token\"
  scope: publish-update (or publish-new for first time)
\`\`\`

\`\`\`
GitHub repo → Settings → Secrets and variables → Actions → New repository secret
  name:  CARGO_REGISTRY_TOKEN
  value: <발급받은 토큰>
\`\`\`

**2. 이름 충돌 해결 필요 ⚠️**

\`cargo publish --dry-run\`을 로컬에서 실행해보니 다음 경고가 떴습니다:

\`\`\`
warning: crate cargo-chrono@0.1.0 already exists on crates.io index
\`\`\`

확인 결과, **\`cargo-chrono\`라는 이름은 이미 [nikomatsakis](https://github.com/nikomatsakis)가 2016년에 점유**한 별개 도구입니다 (Cargo build benchmark/plot 도구, 마지막 업데이트 2020-05-13, 0.2.0).

이 PR을 머지하더라도 첫 \`v0.1.0\` 태그를 푸시하면 publish 단계에서 fail합니다. 선택지:

| 선택지 | 트레이드오프 |
|---|---|
| **A. 다른 이름으로 변경** (예: \`cargo-chronograph\`, \`cargo-chronoscope\`, \`cargo-buildscope\`) | 가장 빠름, 안전. README/Cargo.toml/문서 업데이트 필요 |
| **B. crates.io 운영팀에 양도 요청** ([정책](https://crates.io/policies)에 따라 6년 abandoned 크레이트는 양도 가능성 있음) | 시간 걸림, 결과 불확실 |
| **C. 일단 GitHub release만 사용, crates.io publish는 보류** | release.yml은 비활성 상태로 머지, 이름 결정 후 활성화 |

이 PR은 워크플로 자체에는 영향이 없으므로 일단 머지 가능 — 첫 release 시점에 이름이 정해져 있으면 됩니다.

## 테스트

- [x] \`cargo check\` 통과
- [x] \`cargo publish --dry-run --allow-dirty\` 로컬 실행 — 패키징 성공, 다만 위 이름 충돌 경고
- [ ] 실제 첫 release는 이름 결정 후

## 리뷰어 참고사항

**Option A vs B/C 선택 근거:**
직전 대화에서 사용자가 명시적으로 Option A(crates.io publish 전용, 바이너리 배포 X)를 선택했습니다. 사용자가 Rust 개발자 대상이라 \`cargo install\`로 충분하고, cargo-dist나 multi-OS matrix는 향후 필요 시 별도 PR로 추가하면 됩니다.

**Defensive 장치:**
- 태그-Cargo.toml version 일치 검증 → 손가락 실수로 잘못된 태그 푸시해도 안전
- \`cargo test\` → publish 시점에 master가 깨져 있으면 안 됨
- \`cargo publish --dry-run\` → 패키지 메타데이터 누락 / 의존성 문제 사전 감지