### PR TITLE
chore: rename project to cargo-chronoscope

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing Guide
 
-cargo-chrono에 기여해주셔서 감사합니다.
+cargo-chronoscope에 기여해주셔서 감사합니다.
 
 ## 개발 환경 설정
 
 ```bash
 # 저장소 클론
 git clone <repo-url>
-cd cargo-chrono
+cd cargo-chronoscope
 
 # 빌드 확인
 cargo check

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ assignees: ''
 
 ## 재현 단계
 
-1. `cargo-chrono ...` 실행
+1. `cargo-chronoscope ...` 실행
 2. ...
 3. ...
 
@@ -28,7 +28,7 @@ assignees: ''
 
 - OS: <!-- e.g. macOS 14.5, Ubuntu 24.04 -->
 - Rust: <!-- `rustc --version` 출력 -->
-- cargo-chrono: <!-- `cargo-chrono --version` 또는 커밋 해시 -->
+- cargo-chronoscope: <!-- `cargo-chronoscope --version` 또는 커밋 해시 -->
 
 ## 추가 컨텍스트
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-# CLAUDE.md — cargo-chrono
+# CLAUDE.md — cargo-chronoscope
 
 이 파일은 AI 코딩 어시스턴트(Claude Code 등)가 이 프로젝트에서 작업할 때 따라야 할 규칙과 컨텍스트입니다.
 
 ## 프로젝트 개요
 
-cargo-chrono는 Rust의 Cargo 빌드 이벤트 스트림을 수집·저장·분석하는 CLI 도구입니다.
+cargo-chronoscope는 Rust의 Cargo 빌드 이벤트 스트림을 수집·저장·분석하는 CLI 도구입니다.
 4개 명령(record, watch, ls, diff)을 제공하며, 3인 팀이 모듈별로 분리 개발합니다.
 
 ## 빌드 & 검증 명령
@@ -89,7 +89,7 @@ Supervisor → Parser → Broker ─┬→ Persister → DB
 - `CompilationFinished`에는 `duration`, `started_at`, `finished_at`가 항상 포함
 
 ### DB 위치
-`<project_root>/.cargo-chrono/history.db` (SQLite, WAL mode)
+`<project_root>/.cargo-chronoscope/history.db` (SQLite, WAL mode)
 
 ### BuildId 발급
 Persister가 `BuildStarted` 이벤트를 받을 때 DB INSERT → AUTOINCREMENT로 발급

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "cargo-chrono"
+name = "cargo-chronoscope"
 version = "0.1.0"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/ymw0407/cargo-chrono"
-homepage = "https://github.com/ymw0407/cargo-chrono"
+repository = "https://github.com/ymw0407/cargo-chronoscope"
+homepage = "https://github.com/ymw0407/cargo-chronoscope"
 keywords = ["cargo", "build", "performance", "profiling"]
 categories = ["development-tools::profiling", "command-line-utilities"]
 
 [[bin]]
-name = "cargo-chrono"
+name = "cargo-chronoscope"
 path = "src/main.rs"
 
 [[example]]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The cargo-chrono Authors
+Copyright (c) 2026 The cargo-chronoscope Authors
 (see docs/internal/ROLE_OWNERSHIP.md for the contributor list)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# cargo-chrono
+# cargo-chronoscope
 
 > Cargo build performance observer — record, diff, and watch your Rust builds.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-`cargo-chrono` consumes Cargo's machine-readable build event stream, persists
+`cargo-chronoscope` consumes Cargo's machine-readable build event stream, persists
 each build to a local SQLite database, and gives you four ways to look at the
 results: a real-time TUI dashboard while a build is running, a list of past
 builds, a diff between any two builds, and a baseline-aware anomaly classifier
@@ -20,10 +20,10 @@ analyses historical trends.
 
 | Command | What it does |
 |---|---|
-| `cargo-chrono record [-- <cargo args>]` | Run a `cargo build`, record every compilation event to the local database. |
-| `cargo-chrono watch [-- <cargo args>]`  | Same as `record`, plus a live ratatui dashboard showing active crates, anomaly verdicts, and CPU/memory. |
-| `cargo-chrono ls [--last N]`            | List the most recent builds (default: 10). |
-| `cargo-chrono diff <before> <after>`    | Compare two recorded builds: total time, per-crate movers, and side-by-side critical paths. |
+| `cargo-chronoscope record [-- <cargo args>]` | Run a `cargo build`, record every compilation event to the local database. |
+| `cargo-chronoscope watch [-- <cargo args>]`  | Same as `record`, plus a live ratatui dashboard showing active crates, anomaly verdicts, and CPU/memory. |
+| `cargo-chronoscope ls [--last N]`            | List the most recent builds (default: 10). |
+| `cargo-chronoscope diff <before> <after>`    | Compare two recorded builds: total time, per-crate movers, and side-by-side critical paths. |
 
 Other things it does:
 
@@ -34,7 +34,7 @@ Other things it does:
 - **Cancellation-aware recording** — pressing `q` or `Ctrl-C` mid-build
   discards the partial data instead of polluting your baselines with a
   half-recorded build.
-- **Concurrent-safe storage** — multiple `cargo-chrono` processes can share
+- **Concurrent-safe storage** — multiple `cargo-chronoscope` processes can share
   the same database; SQLite's `busy_timeout` and a transactional migration
   serialise the few moments where it matters.
 
@@ -43,12 +43,12 @@ Other things it does:
 ### From source (current option)
 
 ```bash
-git clone https://github.com/ymw0407/cargo-chrono.git
-cd cargo-chrono
+git clone https://github.com/ymw0407/cargo-chronoscope.git
+cd cargo-chronoscope
 cargo install --path .
 ```
 
-This puts `cargo-chrono` on your `PATH` (typically `~/.cargo/bin`).
+This puts `cargo-chronoscope` on your `PATH` (typically `~/.cargo/bin`).
 
 A crates.io release will follow once the API stabilises.
 
@@ -60,22 +60,22 @@ cd ~/your-rust-project
 
 # Watch a build live.
 cargo clean
-cargo-chrono watch
+cargo-chronoscope watch
 
 # Or record without a UI, then inspect later.
 cargo clean
-cargo-chrono record
+cargo-chronoscope record
 
-cargo-chrono ls
-cargo-chrono diff 1 2
+cargo-chronoscope ls
+cargo-chronoscope diff 1 2
 ```
 
-`cargo-chrono` runs `cargo build` in the current directory and stores its
-data in `./.cargo-chrono/history.db` (SQLite, WAL mode). Add this directory
+`cargo-chronoscope` runs `cargo build` in the current directory and stores its
+data in `./.cargo-chronoscope/history.db` (SQLite, WAL mode). Add this directory
 to your `.gitignore`:
 
 ```gitignore
-.cargo-chrono/
+.cargo-chronoscope/
 ```
 
 ## Usage
@@ -83,9 +83,9 @@ to your `.gitignore`:
 ### `record` — store a build for later analysis
 
 ```bash
-cargo-chrono record                   # cargo build
-cargo-chrono record -- --release      # cargo build --release
-cargo-chrono record -- -p my_crate    # cargo build -p my_crate
+cargo-chronoscope record                   # cargo build
+cargo-chronoscope record -- --release      # cargo build --release
+cargo-chronoscope record -- -p my_crate    # cargo build -p my_crate
 ```
 
 Anything after `--` is forwarded verbatim to `cargo build`. On success it
@@ -95,12 +95,12 @@ get `Build interrupted — not recorded.` instead.
 ### `watch` — record + live TUI dashboard
 
 ```bash
-cargo-chrono watch
-cargo-chrono watch -- --release
+cargo-chronoscope watch
+cargo-chronoscope watch -- --release
 ```
 
 ```
-┌─ cargo-chrono ───────────────────────────────────────┐
+┌─ cargo-chronoscope ───────────────────────────────────────┐
 │ Build #5 (release) • commit abc1234 • elapsed 0:28   │
 │ 142 crates compiled                                  │
 ├─ Active compilations ────────────────────────────────┤
@@ -125,8 +125,8 @@ cache hit.
 ### `ls` — list builds
 
 ```bash
-cargo-chrono ls
-cargo-chrono ls --last 30
+cargo-chronoscope ls
+cargo-chronoscope ls --last 30
 ```
 
 ```
@@ -140,7 +140,7 @@ ID     Started              Profile  Duration   Status
 ### `diff` — compare two builds
 
 ```bash
-cargo-chrono diff 1 2
+cargo-chronoscope diff 1 2
 ```
 
 ```
@@ -208,7 +208,7 @@ Markers:
 
 ## Database schema
 
-A single SQLite file at `<workspace>/.cargo-chrono/history.db`:
+A single SQLite file at `<workspace>/.cargo-chronoscope/history.db`:
 
 ```
 builds
@@ -224,7 +224,7 @@ WAL mode is enabled. `crate_compilations.build_id` references `builds.id`
 (no `ON DELETE CASCADE` — `delete_build` removes both rows in one
 transaction).
 
-You can query the database directly with `sqlite3 .cargo-chrono/history.db`
+You can query the database directly with `sqlite3 .cargo-chronoscope/history.db`
 if you want.
 
 ## Status
@@ -239,7 +239,7 @@ Known gaps:
   timing report could feed the same database).
 - `anomaly` thresholds are not configurable from the CLI (hardcoded to 2σ).
 
-See [issues](https://github.com/ymw0407/cargo-chrono/issues) for the
+See [issues](https://github.com/ymw0407/cargo-chronoscope/issues) for the
 prioritised list.
 
 ## Contributing

--- a/docs/internal/AGENTS.md
+++ b/docs/internal/AGENTS.md
@@ -26,7 +26,7 @@ cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ### 프롬프트 템플릿
 
 ```
-나는 cargo-chrono 프로젝트의 [역할] 담당이다.
+나는 cargo-chronoscope 프로젝트의 [역할] 담당이다.
 CLAUDE.md와 AGENTS.md를 먼저 읽고 프로젝트 규칙을 따라라.
 
 [작업 내용]

--- a/docs/internal/CONCURRENCY.md
+++ b/docs/internal/CONCURRENCY.md
@@ -1,6 +1,6 @@
 # 동시성 & Race Condition 분석
 
-cargo-chrono는 5개의 async task가 동시에 동작하는 파이프라인이다.
+cargo-chronoscope는 5개의 async task가 동시에 동작하는 파이프라인이다.
 이 문서는 **예상되는 race condition과 대응 전략**을 모듈/구현자별로 정리한다.
 구현 전에 이 문서를 읽고, 구현 후에는 체크리스트의 각 항목이 처리됐는지 확인한다.
 
@@ -40,7 +40,7 @@ Watch:   Supervisor ──▶ Parser ──▶ Broker ─┬──▶ Persister 
 - cargo stdout pipe의 OS 버퍼(보통 64KB)가 차면 cargo의 write syscall도 블록
 - **cargo 빌드가 실제로 멈춘다**
 
-**증상**: "빌드가 진행 중인데 cargo-chrono가 멈춘 것처럼 보임"
+**증상**: "빌드가 진행 중인데 cargo-chronoscope가 멈춘 것처럼 보임"
 
 **대응**:
 - Parser는 절대 blocking I/O를 하지 않는다. JSON 파싱만 담당(CPU-only).
@@ -75,7 +75,7 @@ let _ = self.child.kill(); // 이미 종료된 경우 에러 무시
 
 **시나리오**:
 - 터미널 포그라운드의 프로세스 그룹 전체에 SIGINT 전달
-- cargo-chrono와 자식 cargo 모두 SIGINT 수신
+- cargo-chronoscope와 자식 cargo 모두 SIGINT 수신
 - cargo가 먼저 죽으면서 stdout 버퍼의 마지막 JSON 라인이 잘릴 수 있음
 - Parser가 불완전한 JSON에 대해 에러 뱉고 종료
 
@@ -355,7 +355,7 @@ println!("Build {} recorded.", persister_result);
 **불변식**:
 - `run_tui`는 반환 전에 반드시 raw mode를 복원해야 한다.
 - `run_persister`는 반환 시 항상 마지막 `finalize_build`를 호출한 상태여야 한다 (성공/실패 무관).
-- `cargo` 프로세스는 cargo-chrono보다 먼저 종료돼야 한다 (좀비 방지).
+- `cargo` 프로세스는 cargo-chronoscope보다 먼저 종료돼야 한다 (좀비 방지).
 
 ---
 

--- a/docs/internal/DESIGN.md
+++ b/docs/internal/DESIGN.md
@@ -1,12 +1,12 @@
-# cargo-chrono 설계 문서
+# cargo-chronoscope 설계 문서
 
 ## 1. 프로젝트 개요
 
-`cargo-chrono`는 Rust의 빌드 도구 Cargo가 생성하는 빌드 이벤트 스트림을 수집·저장·분석하여
+`cargo-chronoscope`는 Rust의 빌드 도구 Cargo가 생성하는 빌드 이벤트 스트림을 수집·저장·분석하여
 빌드 성능을 관측하는 CLI 도구이다.
 
 Cargo는 `--message-format=json` 플래그를 통해 빌드 과정의 모든 이벤트를 JSON 스트림으로
-내보낸다. cargo-chrono는 이 스트림을 파싱하여 로컬 SQLite 데이터베이스에 기록하고,
+내보낸다. cargo-chronoscope는 이 스트림을 파싱하여 로컬 SQLite 데이터베이스에 기록하고,
 과거 빌드와의 비교(diff) 및 실시간 모니터링(watch) 기능을 제공한다.
 
 ## 2. 문제 정의
@@ -49,16 +49,16 @@ Cargo의 JSON 출력을 파싱하여 내부 `BuildEvent` enum으로 변환한다
 ```
 # 1. main 브랜치에서 빌드 기록
 $ git checkout main
-$ cargo-chrono record -- --release
+$ cargo-chronoscope record -- --release
   ✓ Build #41 recorded (32.4s, 187 crates)
 
 # 2. feature 브랜치에서 빌드 기록
 $ git checkout feat/add-telemetry
-$ cargo-chrono record -- --release
+$ cargo-chronoscope record -- --release
   ✓ Build #42 recorded (38.1s, 193 crates)
 
 # 3. 비교
-$ cargo-chrono diff 41 42
+$ cargo-chronoscope diff 41 42
   Build #41 (main, 32.4s) → Build #42 (feat/add-telemetry, 38.1s)
   Total: +5.7s (+17.6%)
 
@@ -75,9 +75,9 @@ $ cargo-chrono diff 41 42
 ### 시나리오 2: watch — "빌드가 왜 이렇게 오래 걸리지?"
 
 ```
-$ cargo-chrono watch -- --release
+$ cargo-chronoscope watch -- --release
 
-┌─ cargo-chrono watch ─────────────────────────────────────┐
+┌─ cargo-chronoscope watch ─────────────────────────────────────┐
 │ Build #43  ▸ release  ▸ commit a1b2c3d                    │
 │ Elapsed: 0:18 / ~0:33  ████████████░░░░░░░░ 55%          │
 │                                                           │

--- a/docs/internal/PROJECT_HISTORY.md
+++ b/docs/internal/PROJECT_HISTORY.md
@@ -1,7 +1,7 @@
 # Project History
 
 A factual record of what was built, by whom, and when. Kept in chronological
-order — most recent at the bottom. Use [`git log`](https://github.com/ymw0407/cargo-chrono/commits/main)
+order — most recent at the bottom. Use [`git log`](https://github.com/ymw0407/cargo-chronoscope/commits/main)
 for the full per-commit detail.
 
 ## Phase 1 — Skeleton (2026-04-26 → 2026-04-28)
@@ -53,15 +53,15 @@ Tracked via GitHub issues from this point forward.
 | 2026-05-03 | [#9][i9] filed: Ctrl-C builds are recorded as `FAIL` and pollute baselines | issue #9 | @ymw0407 |
 | 2026-05-03 | `persist`: `BuildRepository::delete_build` for cancelled builds | [PR #10][pr10] | @ymw0407 |
 | 2026-05-03 | `main`: discard build record when user cancels with Ctrl-C / `q` | PR #10 | @ymw0407 |
-| 2026-05-03 | [#3][i3] revisited: SQLITE_BUSY race on concurrent `cargo-chrono` processes | issue #3 | @ymw0407 |
+| 2026-05-03 | [#3][i3] revisited: SQLITE_BUSY race on concurrent `cargo-chronoscope` processes | issue #3 | @ymw0407 |
 | 2026-05-03 | `persist`: 5s `busy_timeout` on connection open | [PR #11][pr11] | @ymw0407 |
 | 2026-05-03 | `persist`: atomic migrations with `PRAGMA user_version` guard | PR #11 | @ymw0407 |
 | 2026-05-03 | Open-source release prep: MIT LICENSE, English README, planning docs moved to `docs/internal/` | this PR | @ymw0407 |
 
-[i3]: https://github.com/ymw0407/cargo-chrono/issues/3
-[i9]: https://github.com/ymw0407/cargo-chrono/issues/9
-[pr10]: https://github.com/ymw0407/cargo-chrono/pull/10
-[pr11]: https://github.com/ymw0407/cargo-chrono/pull/11
+[i3]: https://github.com/ymw0407/cargo-chronoscope/issues/3
+[i9]: https://github.com/ymw0407/cargo-chronoscope/issues/9
+[pr10]: https://github.com/ymw0407/cargo-chronoscope/pull/10
+[pr11]: https://github.com/ymw0407/cargo-chronoscope/pull/11
 
 ## Status snapshot at release prep
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -1,6 +1,6 @@
 # `docs/internal/` — historical and team-internal documents
 
-These documents come from the planning phase of `cargo-chrono` (April–May 2026)
+These documents come from the planning phase of `cargo-chronoscope` (April–May 2026)
 and from the post-completion record. They are checked in for context but are
 **not user-facing documentation** — for that, see the top-level
 [`README.md`](../../README.md).

--- a/docs/internal/ROLE_OWNERSHIP.md
+++ b/docs/internal/ROLE_OWNERSHIP.md
@@ -43,10 +43,10 @@ Recent examples:
 - [PR #11][pr11] — `fix/data/concurrent-db-access`: pure Data work
   (busy_timeout, atomic migrations). Tracked via [issue #3][i3].
 
-[pr10]: https://github.com/ymw0407/cargo-chrono/pull/10
-[pr11]: https://github.com/ymw0407/cargo-chrono/pull/11
-[i3]: https://github.com/ymw0407/cargo-chrono/issues/3
-[i9]: https://github.com/ymw0407/cargo-chrono/issues/9
+[pr10]: https://github.com/ymw0407/cargo-chronoscope/pull/10
+[pr11]: https://github.com/ymw0407/cargo-chronoscope/pull/11
+[i3]: https://github.com/ymw0407/cargo-chronoscope/issues/3
+[i9]: https://github.com/ymw0407/cargo-chronoscope/issues/9
 
 ## Branch naming convention
 

--- a/examples/ratatui_hello.rs
+++ b/examples/ratatui_hello.rs
@@ -28,7 +28,7 @@ fn main() -> io::Result<()> {
         terminal.draw(|frame| {
             let area = frame.area();
 
-            let greeting = Paragraph::new("Hello, cargo-chrono! Press 'q' to quit.")
+            let greeting = Paragraph::new("Hello, cargo-chronoscope! Press 'q' to quit.")
                 .alignment(Alignment::Center)
                 .block(
                     Block::default()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,9 +6,9 @@ use clap::{Parser, Subcommand};
 
 use crate::model::{Build, BuildDiff, BuildId, CrateChange, DurationChange};
 
-/// cargo-chrono — Cargo build performance observer.
+/// cargo-chronoscope — Cargo build performance observer.
 #[derive(Parser, Debug)]
-#[command(name = "cargo-chrono", version, about)]
+#[command(name = "cargo-chronoscope", version, about)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn parse_ls_defaults_last_to_10() {
-        let cli = Cli::try_parse_from(["cargo-chrono", "ls"]).unwrap();
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "ls"]).unwrap();
         match cli.command {
             Command::Ls { last } => assert_eq!(last, 10),
             other => panic!("expected Ls, got {:?}", other),
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn parse_ls_with_explicit_last() {
-        let cli = Cli::try_parse_from(["cargo-chrono", "ls", "--last", "5"]).unwrap();
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "ls", "--last", "5"]).unwrap();
         match cli.command {
             Command::Ls { last } => assert_eq!(last, 5),
             _ => panic!("expected Ls"),
@@ -320,8 +320,8 @@ mod tests {
 
     #[test]
     fn parse_record_forwards_cargo_args() {
-        let cli =
-            Cli::try_parse_from(["cargo-chrono", "record", "--release", "-p", "demo"]).unwrap();
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "record", "--release", "-p", "demo"])
+            .unwrap();
         match cli.command {
             Command::Record { cargo_args } => {
                 assert_eq!(cargo_args, vec!["--release", "-p", "demo"]);
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn parse_watch_forwards_cargo_args() {
-        let cli = Cli::try_parse_from(["cargo-chrono", "watch", "--release"]).unwrap();
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "watch", "--release"]).unwrap();
         match cli.command {
             Command::Watch { cargo_args } => {
                 assert_eq!(cargo_args, vec!["--release"]);
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn parse_diff_requires_two_ids() {
-        let cli = Cli::try_parse_from(["cargo-chrono", "diff", "3", "7"]).unwrap();
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "diff", "3", "7"]).unwrap();
         match cli.command {
             Command::Diff { before, after } => {
                 assert_eq!(before, 3);
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn parse_diff_missing_args_errors() {
-        let result = Cli::try_parse_from(["cargo-chrono", "diff", "1"]);
+        let result = Cli::try_parse_from(["cargo-chronoscope", "diff", "1"]);
         assert!(result.is_err());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! cargo-chrono — Cargo build performance observer.
+//! cargo-chronoscope — Cargo build performance observer.
 //!
 //! Entry point that parses CLI arguments and dispatches to the appropriate
 //! command handler. Assembles all async tasks and manages graceful shutdown.
@@ -28,7 +28,7 @@ use crate::model::BuildId;
 use crate::persist::BuildRepository;
 
 /// Default DB directory name within the project root.
-const DB_DIR: &str = ".cargo-chrono";
+const DB_DIR: &str = ".cargo-chronoscope";
 /// Default DB file name.
 const DB_FILE: &str = "history.db";
 

--- a/src/model/ids.rs
+++ b/src/model/ids.rs
@@ -1,4 +1,4 @@
-//! Core identifier types used throughout cargo-chrono.
+//! Core identifier types used throughout cargo-chronoscope.
 
 use std::fmt;
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,4 @@
-//! Shared domain types for cargo-chrono.
+//! Shared domain types for cargo-chronoscope.
 //!
 //! This module is owned by the Integrator and may be imported from any other module.
 //! No module in `model/` may depend on any other `src/` module.

--- a/src/persist/migrations.rs
+++ b/src/persist/migrations.rs
@@ -1,12 +1,12 @@
 //! Database schema migrations.
 //!
-//! Contains the SQL DDL for creating the cargo-chrono tables and indices.
+//! Contains the SQL DDL for creating the cargo-chronoscope tables and indices.
 //! Called by `SqliteRepository::open()` on first use.
 //!
 //! # Concurrency
 //!
 //! Migrations run inside a `BEGIN IMMEDIATE` transaction so a second
-//! `cargo-chrono` process opening the same DB file blocks until the first
+//! `cargo-chronoscope` process opening the same DB file blocks until the first
 //! finishes (or times out). The current `PRAGMA user_version` is checked
 //! inside the transaction; if it already matches `SCHEMA_VERSION`, the
 //! migration is a no-op. This keeps the open path safe against the race in

--- a/src/persist/sqlite.rs
+++ b/src/persist/sqlite.rs
@@ -27,7 +27,7 @@ impl SqliteRepository {
     /// Open (or create) a SQLite database at the given path.
     ///
     /// - Sets a 5s `busy_timeout` so writer-lock contention from another
-    ///   `cargo-chrono` process retries automatically instead of failing
+    ///   `cargo-chronoscope` process retries automatically instead of failing
     ///   with `SQLITE_BUSY`.
     /// - Enables WAL journal mode for better concurrent read performance.
     /// - Runs any pending schema migrations atomically (see

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -6,7 +6,7 @@
 //!
 //! Layout (top to bottom):
 //! ```text
-//! ┌─ cargo-chrono ────────────────────────────────────────────┐
+//! ┌─ cargo-chronoscope ────────────────────────────────────────────┐
 //! │ Build #N (release)  •  commit abc1234  •  elapsed 0:28   │
 //! │ 142 crates compiled                                        │
 //! ├─ Active compilations ─────────────────────────────────────┤
@@ -110,7 +110,7 @@ fn render_header(frame: &mut Frame, area: Rect, state: &TuiState) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(" cargo-chrono ");
+        .title(" cargo-chronoscope ");
 
     frame.render_widget(Paragraph::new(text).block(block), area);
 }


### PR DESCRIPTION
## 요약

\`cargo-chrono\` 이름이 [nikomatsakis가 2016년에 점유한 별개 crate](https://crates.io/crates/cargo-chrono)와 충돌해 crates.io publish가 불가능. \`cargo-chronoscope\`로 일괄 rename. chrono(시간) + scope(관찰) 합성어로 README의 \"build performance observer\" 정체성과 직접 호응.

## 변경 유형

- [x] chore: 프로젝트 메타데이터 변경

## 변경된 파일 (15개, all replace_all)

- \`Cargo.toml\` — \`name\`, \`[[bin]] name\`
- \`src/main.rs\` — \`DB_DIR\` const, 모듈 doc comment
- \`src/cli/mod.rs\` — clap \`#[command(name)]\`, 테스트 argv[0]
- \`src/{model,persist,tui}/**\` — doc comment, TUI 헤더 라벨
- \`examples/ratatui_hello.rs\` — greeting 문자열
- \`README.md\`, \`AGENTS.md\`, \`CLAUDE.md\` (root)
- \`docs/{DESIGN, CONCURRENCY}.md\`
- \`.github/CONTRIBUTING.md\`, \`.github/ISSUE_TEMPLATE/bug_report.md\`

## 테스트

- [x] \`cargo fmt --check\` 통과
- [x] \`cargo clippy -- -D warnings\` 통과
- [x] \`cargo test\` 통과 (125개)
- [x] crates.io에 \`cargo-chronoscope\` 미점유 확인 (curl로 verify)

## 사용자 영향

- **호출 명령어**: \`cargo chrono ...\` → \`cargo chronoscope ...\`
- **DB 디렉터리**: \`.cargo-chrono/\` → \`.cargo-chronoscope/\`
  (이미 \`.cargo-chrono/history.db\`를 쓰던 사용자는 디렉터리 이름 수동 변경 필요)
- **\`cargo install\` 이름**: \`cargo install cargo-chronoscope\`

## 다른 PR과의 관계

⚠️ 현재 main 기준에서 작업했으므로 다음 PR들이 머지되면 추가 rename이 필요합니다:

| PR | 영향 |
|---|---|
| #12 (영문 README + LICENSE + docs/internal/) | rebase 시 새 영문 README, LICENSE, ROLE_OWNERSHIP, PROJECT_HISTORY에도 \`cargo-chrono\` → \`cargo-chronoscope\` 적용 필요 |
| #10 (Ctrl-C 폐기) | persist trait 변경뿐이라 rename 영향 없음 |
| #11 (DB 동시성) | doc comment에 \`cargo-chrono\` 언급 있을 수 있음 (확인 필요) |
| #13 (release CD) | release.yml의 주석/Cargo.toml repository URL은 그대로 유효 |

권장 머지 순서:
1. #10, #11 (코드 fix, rename과 충돌 거의 없음)
2. #12 (문서 정비, rename과 충돌 — \`cargo-chrono\` 영문 문서를 만들어 놨으므로)
3. **이 PR (rename)** — 이 시점에 모든 \`cargo-chrono\` 일괄 치환
4. #13 (release CD) — rename 후라야 첫 release 가능

또는 단순히 이 PR을 가장 마지막에 rebase해서 모든 \`cargo-chrono\` 잔재를 청소하는 것도 가능.

## GitHub repo 이름

이 PR에는 포함하지 않았습니다. \`https://github.com/ymw0407/cargo-chrono\`를 \`cargo-chronoscope\`로 rename할지는 별도 결정:

- **장점**: 일관성, 새 사용자 직관성
- **단점**: 외부 링크/스타/포크가 모두 자동 redirect되지만 영구적 의존은 위험. 기존 PR #10/#11/#12/#13 URL은 유지됨 (GitHub redirect 처리)

권장: 이 PR 머지 후 별도로 GitHub Settings → Rename. Cargo.toml의 \`repository\` 필드는 redirect로 당분간 동작하지만, 새 URL로 갱신하는 follow-up PR 추가 권장.