### PR TITLE
feat(cli): add --format json to ls and diff

### DIFF
--- a/src/cli/json.rs
+++ b/src/cli/json.rs
@@ -1,0 +1,252 @@
+//! Stable JSON wire format for CLI output.
+//!
+//! Domain types in `model::` deliberately do not derive `Serialize`: their
+//! shape is an internal contract and may change as the persistence layer
+//! evolves. The DTOs in this module define the *external* JSON schema that
+//! CI integrations and downstream tooling consume, so we control its
+//! stability separately.
+//!
+//! ## Conventions
+//! - Durations are emitted as integer milliseconds.
+//! - Build IDs are integers (no `#` prefix), so they can be passed back to
+//!   `cargo-chronoscope diff` directly.
+//! - `crate_id` is a flat object `{ "name": "...", "version": "..." | null }`.
+
+use serde::Serialize;
+
+use crate::model::{Build, BuildDiff, CrateChange, CrateId, DurationChange};
+
+/// JSON envelope for `cargo-chronoscope ls --format json`.
+#[derive(Debug, Serialize)]
+pub struct LsJson {
+    pub builds: Vec<BuildJson>,
+}
+
+/// JSON shape of a single recorded build.
+#[derive(Debug, Serialize)]
+pub struct BuildJson {
+    pub id: i64,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub commit_hash: Option<String>,
+    pub cargo_args: String,
+    pub profile: String,
+    pub success: Option<bool>,
+    pub duration_ms: Option<u128>,
+}
+
+impl From<&Build> for BuildJson {
+    fn from(b: &Build) -> Self {
+        Self {
+            id: b.id.0,
+            started_at: b.started_at.clone(),
+            finished_at: b.finished_at.clone(),
+            commit_hash: b.commit_hash.clone(),
+            cargo_args: b.cargo_args.clone(),
+            profile: b.profile.clone(),
+            success: b.success,
+            duration_ms: b.total_duration.map(|d| d.as_millis()),
+        }
+    }
+}
+
+/// JSON shape returned by `cargo-chronoscope diff --format json`.
+#[derive(Debug, Serialize)]
+pub struct DiffJson {
+    pub before: i64,
+    pub after: i64,
+    pub total: DurationChangeJson,
+    pub crate_changes: Vec<CrateChangeJson>,
+    pub critical_path_before: Vec<String>,
+    pub critical_path_after: Vec<String>,
+}
+
+/// JSON shape of a duration change between two builds.
+#[derive(Debug, Serialize)]
+pub struct DurationChangeJson {
+    pub before_ms: u128,
+    pub after_ms: u128,
+    pub delta_ms: i64,
+    pub pct_delta: f64,
+}
+
+impl From<&DurationChange> for DurationChangeJson {
+    fn from(c: &DurationChange) -> Self {
+        Self {
+            before_ms: c.before.as_millis(),
+            after_ms: c.after.as_millis(),
+            delta_ms: c.abs_delta_ms,
+            pct_delta: c.pct_delta,
+        }
+    }
+}
+
+/// JSON shape of a crate identifier.
+#[derive(Debug, Serialize)]
+pub struct CrateIdJson {
+    pub name: String,
+    pub version: Option<String>,
+}
+
+impl From<&CrateId> for CrateIdJson {
+    fn from(c: &CrateId) -> Self {
+        Self {
+            name: c.name.clone(),
+            version: c.version.clone(),
+        }
+    }
+}
+
+/// JSON shape of a single crate change. Tagged by `kind` for easy parsing.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum CrateChangeJson {
+    Added {
+        crate_id: CrateIdJson,
+        duration_ms: u128,
+    },
+    Removed {
+        crate_id: CrateIdJson,
+        duration_ms: u128,
+    },
+    Changed {
+        crate_id: CrateIdJson,
+        change: DurationChangeJson,
+    },
+    Unchanged {
+        crate_id: CrateIdJson,
+        duration_ms: u128,
+    },
+}
+
+impl From<&CrateChange> for CrateChangeJson {
+    fn from(c: &CrateChange) -> Self {
+        match c {
+            CrateChange::Added { crate_id, duration } => Self::Added {
+                crate_id: crate_id.into(),
+                duration_ms: duration.as_millis(),
+            },
+            CrateChange::Removed { crate_id, duration } => Self::Removed {
+                crate_id: crate_id.into(),
+                duration_ms: duration.as_millis(),
+            },
+            CrateChange::Changed { crate_id, change } => Self::Changed {
+                crate_id: crate_id.into(),
+                change: change.into(),
+            },
+            CrateChange::Unchanged { crate_id, duration } => Self::Unchanged {
+                crate_id: crate_id.into(),
+                duration_ms: duration.as_millis(),
+            },
+        }
+    }
+}
+
+impl From<&BuildDiff> for DiffJson {
+    fn from(d: &BuildDiff) -> Self {
+        Self {
+            before: d.before.0,
+            after: d.after.0,
+            total: (&d.total_change).into(),
+            crate_changes: d.crate_changes.iter().map(Into::into).collect(),
+            critical_path_before: d.critical_path_before.clone(),
+            critical_path_after: d.critical_path_after.clone(),
+        }
+    }
+}
+
+/// Render builds as a single-line JSON envelope to stdout.
+pub fn render_ls_json(builds: &[Build]) -> anyhow::Result<()> {
+    let envelope = LsJson {
+        builds: builds.iter().map(Into::into).collect(),
+    };
+    serde_json::to_writer(std::io::stdout(), &envelope)?;
+    println!();
+    Ok(())
+}
+
+/// Render a build diff as a single-line JSON object to stdout.
+pub fn render_diff_json(diff: &BuildDiff) -> anyhow::Result<()> {
+    let dto: DiffJson = diff.into();
+    serde_json::to_writer(std::io::stdout(), &dto)?;
+    println!();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Build, BuildDiff, BuildId, CrateChange, CrateId, DurationChange};
+    use std::time::Duration;
+
+    fn sample_build() -> Build {
+        Build {
+            id: BuildId(7),
+            started_at: "2026-05-03T01:00:00".into(),
+            finished_at: Some("2026-05-03T01:00:42".into()),
+            commit_hash: Some("abc1234".into()),
+            cargo_args: "[\"--release\"]".into(),
+            profile: "release".into(),
+            success: Some(true),
+            total_duration: Some(Duration::from_millis(42_500)),
+        }
+    }
+
+    #[test]
+    fn build_serializes_with_flat_id_and_ms_duration() {
+        let json = serde_json::to_value(BuildJson::from(&sample_build())).unwrap();
+        assert_eq!(json["id"], 7);
+        assert_eq!(json["duration_ms"], 42_500);
+        assert_eq!(json["profile"], "release");
+        assert_eq!(json["success"], true);
+    }
+
+    #[test]
+    fn ls_envelope_wraps_builds_array() {
+        let envelope = LsJson {
+            builds: vec![BuildJson::from(&sample_build())],
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert!(json["builds"].is_array());
+        assert_eq!(json["builds"][0]["id"], 7);
+    }
+
+    #[test]
+    fn crate_change_is_tagged_by_kind() {
+        let added: CrateChangeJson = (&CrateChange::Added {
+            crate_id: CrateId {
+                name: "serde".into(),
+                version: Some("1.0".into()),
+            },
+            duration: Duration::from_millis(1_500),
+        })
+            .into();
+        let json = serde_json::to_value(&added).unwrap();
+        assert_eq!(json["kind"], "added");
+        assert_eq!(json["crate_id"]["name"], "serde");
+        assert_eq!(json["crate_id"]["version"], "1.0");
+        assert_eq!(json["duration_ms"], 1_500);
+    }
+
+    #[test]
+    fn diff_serializes_with_numeric_ids() {
+        let diff = BuildDiff {
+            before: BuildId(1),
+            after: BuildId(2),
+            total_change: DurationChange {
+                before: Duration::from_millis(1_000),
+                after: Duration::from_millis(1_500),
+                abs_delta_ms: 500,
+                pct_delta: 50.0,
+            },
+            crate_changes: vec![],
+            critical_path_before: vec!["a".into()],
+            critical_path_after: vec!["a".into(), "b".into()],
+        };
+        let json = serde_json::to_value(DiffJson::from(&diff)).unwrap();
+        assert_eq!(json["before"], 1);
+        assert_eq!(json["after"], 2);
+        assert_eq!(json["total"]["delta_ms"], 500);
+        assert_eq!(json["critical_path_after"].as_array().unwrap().len(), 2);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,9 +2,26 @@
 //!
 //! Owned by the Integrator. Uses clap 4 derive macros for argument parsing.
 
-use clap::{Parser, Subcommand};
+pub mod json;
+
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::model::{Build, BuildDiff, BuildId, CrateChange, DurationChange};
+
+/// Output format for `ls` and `diff`.
+///
+/// `Text` is the default human-readable form. `Json` emits a single-line
+/// JSON document on stdout, suitable for CI integrations and downstream
+/// tooling. The JSON schema is defined in [`json`] and is treated as a
+/// stable wire format.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum Format {
+    /// Human-readable table / report (default).
+    #[default]
+    Text,
+    /// Single-line JSON object on stdout.
+    Json,
+}
 
 /// cargo-chronoscope — Cargo build performance observer.
 #[derive(Parser, Debug)]
@@ -36,6 +53,9 @@ pub enum Command {
         /// Number of most recent builds to display.
         #[arg(long, default_value = "10")]
         last: usize,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = Format::Text)]
+        format: Format,
     },
 
     /// Compare two recorded builds.
@@ -44,6 +64,9 @@ pub enum Command {
         before: i64,
         /// Build ID of the "after" build.
         after: i64,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = Format::Text)]
+        format: Format,
     },
 }
 
@@ -304,7 +327,10 @@ mod tests {
     fn parse_ls_defaults_last_to_10() {
         let cli = Cli::try_parse_from(["cargo-chronoscope", "ls"]).unwrap();
         match cli.command {
-            Command::Ls { last } => assert_eq!(last, 10),
+            Command::Ls { last, format } => {
+                assert_eq!(last, 10);
+                assert_eq!(format, Format::Text);
+            }
             other => panic!("expected Ls, got {:?}", other),
         }
     }
@@ -313,9 +339,27 @@ mod tests {
     fn parse_ls_with_explicit_last() {
         let cli = Cli::try_parse_from(["cargo-chronoscope", "ls", "--last", "5"]).unwrap();
         match cli.command {
-            Command::Ls { last } => assert_eq!(last, 5),
+            Command::Ls { last, format } => {
+                assert_eq!(last, 5);
+                assert_eq!(format, Format::Text);
+            }
             _ => panic!("expected Ls"),
         }
+    }
+
+    #[test]
+    fn parse_ls_with_json_format() {
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "ls", "--format", "json"]).unwrap();
+        match cli.command {
+            Command::Ls { format, .. } => assert_eq!(format, Format::Json),
+            _ => panic!("expected Ls"),
+        }
+    }
+
+    #[test]
+    fn parse_ls_rejects_unknown_format() {
+        let result = Cli::try_parse_from(["cargo-chronoscope", "ls", "--format", "yaml"]);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -345,10 +389,25 @@ mod tests {
     fn parse_diff_requires_two_ids() {
         let cli = Cli::try_parse_from(["cargo-chronoscope", "diff", "3", "7"]).unwrap();
         match cli.command {
-            Command::Diff { before, after } => {
+            Command::Diff {
+                before,
+                after,
+                format,
+            } => {
                 assert_eq!(before, 3);
                 assert_eq!(after, 7);
+                assert_eq!(format, Format::Text);
             }
+            _ => panic!("expected Diff"),
+        }
+    }
+
+    #[test]
+    fn parse_diff_with_json_format() {
+        let cli = Cli::try_parse_from(["cargo-chronoscope", "diff", "1", "2", "--format", "json"])
+            .unwrap();
+        match cli.command {
+            Command::Diff { format, .. } => assert_eq!(format, Format::Json),
             _ => panic!("expected Diff"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,11 +59,15 @@ async fn main() -> anyhow::Result<()> {
         Command::Watch { cargo_args } => {
             cmd_watch(cargo_args, workspace_dir, &db_path, cancel).await?;
         }
-        Command::Ls { last } => {
-            cmd_ls(&db_path, last).await?;
+        Command::Ls { last, format } => {
+            cmd_ls(&db_path, last, format).await?;
         }
-        Command::Diff { before, after } => {
-            cmd_diff(&db_path, before, after).await?;
+        Command::Diff {
+            before,
+            after,
+            format,
+        } => {
+            cmd_diff(&db_path, before, after, format).await?;
         }
     }
 
@@ -157,18 +161,29 @@ async fn finalize_or_discard(
 }
 
 /// List recent builds.
-async fn cmd_ls(db_path: &std::path::Path, last: usize) -> anyhow::Result<()> {
+async fn cmd_ls(db_path: &std::path::Path, last: usize, format: cli::Format) -> anyhow::Result<()> {
     let repo = persist::SqliteRepository::open(db_path).await?;
     let builds = repo.list_builds(last).await?;
-    cli::render_ls(&builds);
+    match format {
+        cli::Format::Text => cli::render_ls(&builds),
+        cli::Format::Json => cli::json::render_ls_json(&builds)?,
+    }
     Ok(())
 }
 
 /// Diff two builds.
-async fn cmd_diff(db_path: &std::path::Path, before: i64, after: i64) -> anyhow::Result<()> {
+async fn cmd_diff(
+    db_path: &std::path::Path,
+    before: i64,
+    after: i64,
+    format: cli::Format,
+) -> anyhow::Result<()> {
     let repo = persist::SqliteRepository::open(db_path).await?;
     let build_diff = diff::compute_diff(&repo, BuildId(before), BuildId(after)).await?;
-    cli::render_diff(&build_diff);
+    match format {
+        cli::Format::Text => cli::render_diff(&build_diff),
+        cli::Format::Json => cli::json::render_diff_json(&build_diff)?,
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- New \`--format text|json\` flag on both \`ls\` and \`diff\` (default: \`text\`).
- JSON form emits a single-line document on stdout, suitable for CI and downstream tooling.
- New \`cli::json\` submodule defines DTOs that decouple the wire format from internal domain types — JSON schema can evolve under its own stability rules.

## Wire format highlights
- Durations as integer milliseconds (no nested \`Duration\` shape).
- Build IDs as bare integers (no \`#\` prefix) — pipe straight back into \`diff\`.
- \`crate_changes\` tagged by \`kind\`: \`added\` / \`removed\` / \`changed\` / \`unchanged\`.
- \`ls\` wrapped in a \`{ \"builds\": [...] }\` envelope.

Example:
\`\`\`json
{\"builds\":[{\"id\":7,\"started_at\":\"...\",\"profile\":\"release\",\"success\":true,\"duration_ms\":42500,...}]}
\`\`\`

## Why this PR exists
Unblocks the build-perf CI workflow (PR #17) — it currently parses \`ls\` output with awk, which is fragile. After this lands the workflow can switch to \`--format json\` + \`jq\`.

## Test plan
- [x] \`cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test\` (all green, 137 tests)
- [x] Smoke-tested empty-DB output: \`cargo-chronoscope ls --format json\` → \`{\"builds\":[]}\`
- [ ] After merge: PR #17 (build-perf) is updated to consume the JSON form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)