### PR TITLE
feat(action): composite GitHub Action for cargo-chronoscope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,176 @@
+name: 'cargo-chronoscope'
+description: >-
+  Record and diff Cargo build performance. Caches the history database
+  with the baseline branch as the canonical source, and (optionally)
+  posts a sticky PR comment summarising the change.
+author: 'ymw0407'
+
+branding:
+  icon: 'activity'
+  color: 'orange'
+
+# This action wraps the cargo-chronoscope CLI into a one-step CI flow:
+#
+#   1. Restore the most recent baseline DB from the GitHub Actions cache.
+#   2. Install cargo-chronoscope (from crates.io, with `--locked`).
+#   3. Run `cargo-chronoscope record` against the project under test.
+#   4. Render a Markdown diff (current build vs. previous build) into
+#      $GITHUB_STEP_SUMMARY, and -- on pull_request runs -- as a sticky
+#      PR comment identified by a hidden marker so it updates in place.
+#   5. Save the updated DB back to the cache, but only on baseline-branch
+#      pushes, so PR runs never overwrite the baseline.
+#
+# The action is intentionally `composite` (not Docker / JS) so it inherits
+# the calling workflow's Rust toolchain and its rust-cache state. The
+# caller is responsible for setting up Rust before invoking this action.
+
+inputs:
+  version:
+    description: >-
+      cargo-chronoscope version to install. Use a concrete version like
+      `0.1.1` for reproducibility, or `latest` to track the newest crate.
+    required: false
+    default: 'latest'
+  cargo-args:
+    description: >-
+      Arguments forwarded verbatim to `cargo build` via
+      `cargo-chronoscope record -- <args>`. Default: `--release`.
+    required: false
+    default: '--release'
+  baseline-ref:
+    description: >-
+      Branch whose chronoscope DB is the baseline. Only pushes to this
+      ref are allowed to update the cached DB.
+    required: false
+    default: 'main'
+  cache-key-prefix:
+    description: >-
+      Prefix for the GitHub Actions cache key holding the DB.
+    required: false
+    default: 'chronoscope-db'
+  comment:
+    description: >-
+      Post (or update) a sticky PR comment with the diff. `true` or
+      `false`. Forked-PR runs receive a read-only token, so posting may
+      fail silently — the workflow itself continues regardless.
+    required: false
+    default: 'true'
+  github-token:
+    description: >-
+      Token used to post PR comments. Defaults to ${{ github.token }}.
+      Only used when `comment` is `true` and the event is a pull_request.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  build-id:
+    description: 'The build ID assigned to this run by chronoscope.'
+    value: ${{ steps.report.outputs.build-id }}
+  report-path:
+    description: 'Path (relative to the workspace) of the rendered Markdown report.'
+    value: ${{ steps.report.outputs.report-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore chronoscope history
+      uses: actions/cache/restore@v4
+      with:
+        path: .cargo-chronoscope/history.db
+        key: ${{ inputs.cache-key-prefix }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-
+
+    - name: Install cargo-chronoscope
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [ "$VERSION" = "latest" ]; then
+          cargo install cargo-chronoscope --locked
+        else
+          cargo install cargo-chronoscope --version "$VERSION" --locked
+        fi
+
+    - name: Record build
+      shell: bash
+      env:
+        CARGO_ARGS: ${{ inputs.cargo-args }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC2086 # CARGO_ARGS is a deliberate word-split.
+        cargo-chronoscope record -- $CARGO_ARGS
+
+    - name: Render diff report
+      id: report
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Pull the two most recent build IDs as integers, newest first.
+        # When --format json is available (>=0.1.1) this becomes:
+        #   ids=($(cargo-chronoscope ls --last 2 --format json | jq '.builds[].id'))
+        mapfile -t ids < <(cargo-chronoscope ls --last 2 \
+          | awk '/^#[0-9]+/ {gsub(/#/,"",$1); print $1}')
+
+        report="perf-report.md"
+        {
+          if [ "${#ids[@]}" -lt 2 ]; then
+            echo "## Build performance"
+            echo ""
+            echo "_Only one build recorded so far — nothing to diff._"
+          else
+            before="${ids[1]}"
+            after="${ids[0]}"
+            echo "## Build performance: #${before} → #${after}"
+            echo ""
+            echo '```'
+            cargo-chronoscope diff "$before" "$after"
+            echo '```'
+          fi
+        } > "$report"
+        cat "$report"
+
+        echo "report-path=$report" >> "$GITHUB_OUTPUT"
+        if [ "${#ids[@]}" -ge 1 ]; then
+          echo "build-id=${ids[0]}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Append report to step summary
+      shell: bash
+      run: cat perf-report.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Post / update sticky PR comment
+      if: inputs.comment == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        marker='<!-- chronoscope-perf-comment -->'
+        { echo "$marker"; echo ""; cat perf-report.md; } > comment.md
+
+        existing_id=$(gh api \
+          "repos/${REPO}/issues/${PR}/comments" \
+          --paginate \
+          --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+
+        if [ -n "$existing_id" ]; then
+          jq -Rs '{body: .}' comment.md \
+            | gh api "repos/${REPO}/issues/comments/${existing_id}" \
+                -X PATCH --input -
+          echo "Updated existing PR comment ${existing_id}."
+        else
+          gh pr comment "$PR" --body-file comment.md
+          echo "Created new PR comment."
+        fi
+
+    - name: Save chronoscope history
+      if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', inputs.baseline-ref)
+      uses: actions/cache/save@v4
+      with:
+        path: .cargo-chronoscope/history.db
+        key: ${{ inputs.cache-key-prefix }}-${{ github.sha }}

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,12 @@ branding:
 inputs:
   version:
     description: >-
-      cargo-chronoscope version to install. Use a concrete version like
-      `0.1.1` for reproducibility, or `latest` to track the newest crate.
+      cargo-chronoscope version to install. Pinning a concrete version
+      (e.g. `0.1.1`) gives reproducible runs; `latest` always pulls the
+      newest published crate. Defaults to the oldest version that
+      supports the `--format json` parsing path used internally.
     required: false
-    default: 'latest'
+    default: '0.1.1'
   cargo-args:
     description: >-
       Arguments forwarded verbatim to `cargo build` via
@@ -108,10 +110,10 @@ runs:
       run: |
         set -euo pipefail
         # Pull the two most recent build IDs as integers, newest first.
-        # When --format json is available (>=0.1.1) this becomes:
-        #   ids=($(cargo-chronoscope ls --last 2 --format json | jq '.builds[].id'))
-        mapfile -t ids < <(cargo-chronoscope ls --last 2 \
-          | awk '/^#[0-9]+/ {gsub(/#/,"",$1); print $1}')
+        # `ls --format json` returns `{"builds":[{"id": N, ...}, ...]}` with
+        # newest first, so jq's array index gives us [newest, previous].
+        mapfile -t ids < <(cargo-chronoscope ls --last 2 --format json \
+          | jq -r '.builds[].id')
 
         report="perf-report.md"
         {

--- a/examples/ci/build-perf.yml
+++ b/examples/ci/build-perf.yml
@@ -1,0 +1,44 @@
+# Example: how a downstream Rust project would adopt the cargo-chronoscope
+# composite action.
+#
+# Drop a copy of this file at .github/workflows/build-perf.yml in any Rust
+# repository. The action measures cargo build performance, caches the
+# history DB with `main` as the canonical baseline, and posts a sticky
+# diff comment on each pull request.
+#
+# Caller responsibilities:
+#   - Set up the Rust toolchain (the action does NOT do this for you, so it
+#     plays well with whatever Rust version your project pins).
+#   - Avoid using rust-cache on the same job: a warm `target/` would mask
+#     per-crate timing, which is exactly the signal chronoscope measures.
+
+name: Build performance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: ymw0407/cargo-chronoscope@v0.1.0
+        with:
+          # Pin to a specific version for reproducibility, or use `latest`.
+          version: '0.1.0'
+          # Forwarded to `cargo build`. Default is --release; pass an empty
+          # string for a debug build.
+          cargo-args: '--release'
+          # Branch whose DB is the baseline. Only pushes to this ref will
+          # write back to the cache.
+          baseline-ref: 'main'
+          # Sticky PR comment is on by default; set to 'false' to disable.
+          comment: 'true'

--- a/examples/ci/build-perf.yml
+++ b/examples/ci/build-perf.yml
@@ -30,10 +30,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: ymw0407/cargo-chronoscope@v0.1.0
+      - uses: ymw0407/cargo-chronoscope@v0.1.1
         with:
-          # Pin to a specific version for reproducibility, or use `latest`.
-          version: '0.1.0'
+          # cargo-chronoscope binary version pulled from crates.io. Pin a
+          # concrete version for reproducibility, or use `latest`.
+          version: '0.1.1'
           # Forwarded to `cargo build`. Default is --release; pass an empty
           # string for a debug build.
           cargo-args: '--release'


### PR DESCRIPTION
**This PR is intentionally a draft** — it stays open until the action's parsing layer can be switched from \`awk\` to \`jq\` (which requires \`--format json\` from #18 to be released to crates.io).

## Summary
- New top-level \`action.yml\` exposes a composite GitHub Action.
- Downstream Rust repos can adopt the build-perf workflow with a single \`uses: ymw0407/cargo-chronoscope@v0.1.0\` step.
- \`examples/ci/build-perf.yml\` is a copy-pasteable reference workflow.

## Inputs
| input | default | purpose |
|---|---|---|
| \`version\` | \`latest\` | crate version to install |
| \`cargo-args\` | \`--release\` | forwarded to \`cargo build\` |
| \`baseline-ref\` | \`main\` | branch that owns the DB cache |
| \`cache-key-prefix\` | \`chronoscope-db\` | GHA cache key prefix |
| \`comment\` | \`true\` | post / update sticky PR comment |
| \`github-token\` | \`\${{ github.token }}\` | comment-step token override |

## Outputs
- \`build-id\` — chronoscope build ID assigned this run
- \`report-path\` — path to the rendered Markdown diff

## Design notes
- **Composite, not Docker / JS**: the action inherits the caller's Rust toolchain and rust-cache state instead of bundling its own.
- **Caller installs Rust**: the action does not run \`dtolnay/rust-toolchain\` itself, so projects can pin whatever Rust version they like.
- **Cache writes only on baseline-branch pushes** so PR runs never overwrite the canonical baseline.
- **Sticky PR comment** identified by a hidden marker; updated in place via \`gh api ... -X PATCH\` rather than appending.
- **Forked-PR safe**: the comment step is wrapped in \`continue-on-error\` because forked-PR tokens are read-only.

## Release plan (when this PR comes out of draft)
1. Land #18 (\`--format json\`) → cut v0.1.1 release.
2. Update this PR's parser step from awk to \`cargo-chronoscope ls --format json | jq\`.
3. Bump default \`version\` input to \`0.1.1\`.
4. Mark non-draft, merge, tag a major release for the action (e.g. \`v1\`).

## Test plan
- [ ] Action runs cleanly inside this repo's own CI (after toolchain step).
- [ ] Sticky comment created on first PR run and PATCHed on second push.
- [ ] Cache hit on a PR after a baseline-branch push has populated it.
- [ ] Forked PR run completes (with \`continue-on-error\` swallowing the comment step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)