### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"


### PR DESCRIPTION
## Summary
Bumps \`Cargo.toml\` from \`0.1.0\` to \`0.1.1\` so the next release can ship the \`--format json\` flag added in #18.

## Release plan
After this PR merges:
1. \`git tag v0.1.1 && git push origin v0.1.1\`
2. The \`Release\` workflow validates tag↔version match, runs tests, then \`cargo publish\`.
3. v0.1.1 lands on crates.io.

## Test plan
- [x] \`cargo check\` succeeds at the new version locally.
- [ ] Existing CI (\`fmt\`, \`clippy\`, \`test\`) green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)