### PR TITLE
fix(action): shorten description to fit Marketplace 125-char limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 name: 'cargo-chronoscope'
 description: >-
-  Record and diff Cargo build performance. Caches the history database
-  with the baseline branch as the canonical source, and (optionally)
-  posts a sticky PR comment summarising the change.
+  Record and diff Cargo build performance. Caches a baseline DB per
+  branch and posts a sticky PR comment with the diff.
 author: 'ymw0407'
 
 branding:


### PR DESCRIPTION
## Summary
GitHub Marketplace rejects action.yml descriptions over 125 chars when publishing a release. The previous text (~190 chars) blocked registration.

Trims to **117 chars** while keeping the three load-bearing points:
- record + diff
- per-branch baseline cache
- sticky PR comment

New text:
> Record and diff Cargo build performance. Caches a baseline DB per branch and posts a sticky PR comment with the diff.

## Follow-up after merge
The Marketplace publish form is tied to a release tag. The current immutable \`action-v1.0.0\` still points at the old action.yml, so to retry registration you'll need a new tag:

\`\`\`bash
git checkout main && git pull
NEW_SHA=\$(git rev-parse HEAD)
git tag action-v1.0.1 \$NEW_SHA
git tag -f action-v1 \$NEW_SHA            # move major-tag forward
git push origin action-v1.0.1
git push origin action-v1 --force         # only the moving tag is force-pushed
\`\`\`

Then on the Releases page, draft a new release for \`action-v1.0.1\` and publish to Marketplace from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)