### PR TITLE
feat(release): prebuilt binaries + binstall + isolated install cache

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -32,9 +32,22 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Deliberately no rust-cache here: a warm target/ directory makes most
-      # crates compile in ~0s, which masks the per-crate timing signal we
-      # actually want to measure.
+      # Cache scoped to the *install* target directory only.
+      #
+      # The chronoscope binary built from this PR's source must be cached
+      # to keep CI fast, but the workspace's own `./target/` MUST stay
+      # cold so the `record` step measures a full release build with
+      # meaningful per-crate timings. We solve this by giving the install
+      # step a separate target dir (/tmp/install-target via CARGO_TARGET_DIR
+      # below) and pointing rust-cache at that dir alone.
+      #
+      # `save-if` restricts cache writes to baseline-branch pushes so PR
+      # runs never overwrite the canonical install cache.
+      - name: Cache install artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: '. -> /tmp/install-target'
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Restore chronoscope history
         uses: actions/cache/restore@v4
@@ -45,11 +58,18 @@ jobs:
             chronoscope-db-
 
       - name: Install cargo-chronoscope (from this repo's source)
-        # Build the binary from the checked-out source rather than crates.io so
-        # CI exercises the version under review. `--locked` honours Cargo.lock.
+        # Build the binary from the checked-out source rather than crates.io
+        # so CI exercises the version under review. `--locked` honours
+        # Cargo.lock. CARGO_TARGET_DIR sends compiled artifacts to a
+        # scratch path so the workspace's ./target/ remains untouched —
+        # see the rust-cache step above for why this matters.
+        env:
+          CARGO_TARGET_DIR: /tmp/install-target
         run: cargo install --path . --locked
 
       - name: Record build
+        # ./target/ is empty, so this triggers a full cold release build
+        # and produces real per-crate timings for the diff.
         run: cargo-chronoscope record -- --release
 
       - name: Show recent builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 # Triggered by pushing a tag like `v0.1.0`. The tag's version *must* match
 # the `version` field in `Cargo.toml`; the workflow fails fast otherwise.
 #
+# Two parallel deliverables:
+#   - `publish` uploads the crate to crates.io (the canonical source distribution).
+#   - `release-binaries` cross-compiles the bin for the matrix targets and
+#     attaches each archive to the GitHub Release. Downstream consumers can
+#     pull these via `cargo binstall` instead of compiling from source.
+#
 # Required repository secret:
 #   CARGO_REGISTRY_TOKEN — crates.io API token
 #                          (create at https://crates.io/me, scope: publish-update)
@@ -52,3 +58,38 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish
+
+  release-binaries:
+    name: Build & upload (${{ matrix.target }})
+    needs: publish
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-14
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build & attach archive to GitHub Release
+        # Builds in `release` profile, packages the binary as
+        # `cargo-chronoscope-${TARGET}.tar.gz`, and uploads it to the
+        # GitHub Release that this tag created. cargo-binstall consumers
+        # then resolve the archive via the [package.metadata.binstall]
+        # template in Cargo.toml.
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: cargo-chronoscope
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,17 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+# cargo-binstall metadata.
+#
+# Tells `cargo binstall` where the prebuilt archives published by the
+# `release-binaries` job in .github/workflows/release.yml live. The URL
+# template resolves at install time:
+#   - {repo}    → repository URL
+#   - {version} → crate version
+#   - {target}  → host triple (e.g. x86_64-unknown-linux-gnu)
+# Each archive contains the `cargo-chronoscope` binary at its root.
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/v{version}/{name}-{target}.tar.gz"
+bin-dir = "{bin}{binary-ext}"
+pkg-fmt = "tgz"

--- a/action.yml
+++ b/action.yml
@@ -82,16 +82,24 @@ runs:
         restore-keys: |
           ${{ inputs.cache-key-prefix }}-
 
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
+
     - name: Install cargo-chronoscope
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+      # cargo-binstall pulls a prebuilt archive from the GitHub Release that
+      # matches the requested version; on a miss it falls back to building
+      # from source via `cargo install`. Either way the binary lands in
+      # ~/.cargo/bin without polluting the workspace's target/ directory,
+      # which keeps cargo-chronoscope's per-crate timing signal intact.
       run: |
         set -euo pipefail
         if [ "$VERSION" = "latest" ]; then
-          cargo install cargo-chronoscope --locked
+          cargo binstall --no-confirm cargo-chronoscope
         else
-          cargo install cargo-chronoscope --version "$VERSION" --locked
+          cargo binstall --no-confirm --version "$VERSION" cargo-chronoscope
         fi
 
     - name: Record build


### PR DESCRIPTION
## Why
PR #22's CI run took **1m 30s total** with **1m 13s spent in \`cargo install --path .\`**. Worse, because that install populated the workspace \`target/\`, the subsequent \`record\` step finished in 1s — measuring nothing. Build #3 → #4 produced \`0.4s → 0.6s\`, "No crate-level changes", and a critical-path that was just reordering noise.

This PR addresses both problems in one batch.

## Changes

### \`release.yml\` — prebuilt binaries
- New \`release-binaries\` matrix job (\`needs: publish\`) running on \`v*\` tags.
- Targets: \`x86_64-unknown-linux-gnu\`, \`x86_64-apple-darwin\`, \`aarch64-apple-darwin\`.
- Uses \`taiki-e/upload-rust-binary-action\` to package each binary as \`cargo-chronoscope-<target>.tar.gz\` and attach it to the GitHub Release.

### \`Cargo.toml\` — binstall metadata
\`\`\`toml
[package.metadata.binstall]
pkg-url = "{repo}/releases/download/v{version}/{name}-{target}.tar.gz"
bin-dir = "{bin}{binary-ext}"
pkg-fmt = "tgz"
\`\`\`
Tells \`cargo binstall\` how to resolve the URLs. Versions without prebuilt assets (0.1.0, 0.1.1) keep working via binstall's source-build fallback.

### \`action.yml\` — switch to \`cargo binstall\`
- Adds \`cargo-bins/cargo-binstall@main\` to install the binstall tool.
- \`cargo install ...\` → \`cargo binstall --no-confirm ...\`.
- External action consumers pinning a version with prebuilt assets get the binary in seconds instead of compiling for ~1m+.

### \`build-perf.yml\` — isolated install cache (self-CI)
- Install step now runs with \`CARGO_TARGET_DIR=/tmp/install-target\`, leaving the workspace \`./target/\` untouched.
- Adds \`Swatinem/rust-cache@v2\` scoped to \`/tmp/install-target\` with \`save-if\` restricted to baseline-branch pushes.
- Net effect:
  - **First run after merge:** ~2m20s (full install + full cold record).
  - **Subsequent runs:** ~1m20s (cached install + full cold record).
  - **All runs:** measurement is honest — \`record\` builds a real cold release artifact.

## Validation expectations
- [ ] CI on this PR runs the modified \`build-perf.yml\` and produces a \`record\` step that takes >30s (cold build), with non-zero per-crate timings in the diff comment.
- [ ] After merge → bump to v0.1.2 → tag \`v0.1.2\` → release workflow runs \`publish\` then three matrix jobs and uploads three \`.tar.gz\` archives to the v0.1.2 Release.
- [ ] After v0.1.2 ships, retag \`action-v1\` (and add \`action-v1.0.2\`) so external consumers pick up the binstall path.

## Follow-up plan
Once v0.1.2 ships with prebuilt assets:
1. Bump action default \`version\` input from \`0.1.1\` → \`0.1.2\`.
2. Retag the moving \`action-v1\` to point at the latest commit.
3. Optional: add Linux ARM64 / Windows targets to the matrix once needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)