### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"


### PR DESCRIPTION
## Summary
Bumps \`Cargo.toml\` from \`0.1.1\` to \`0.1.2\` so the next release tag triggers the new prebuilt-binary pipeline shipped in #23.

## Release plan
After this PR merges:
1. \`git tag v0.1.2 && git push origin v0.1.2\`
2. \`Release\` workflow runs:
   - \`publish\` — verifies tag↔version, runs tests, \`cargo publish\`.
   - \`release-binaries\` (matrix, \`needs: publish\`) — builds and uploads \`cargo-chronoscope-{x86_64-unknown-linux-gnu,x86_64-apple-darwin,aarch64-apple-darwin}.tar.gz\` to the v0.1.2 GitHub Release.
3. v0.1.2 lands on crates.io with prebuilt assets attached on GitHub.
4. From this point external action consumers using \`cargo binstall\` get the binary in seconds instead of minutes.

## Follow-up after release lands
- Bump \`action.yml\` default \`version\` input \`0.1.1\` → \`0.1.2\`.
- Move \`action-v1\` tag forward (and add \`action-v1.0.2\`) so external pins pick up both the binstall path and the new default version.

## Test plan
- [x] \`cargo check\` succeeds at the new version locally.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)