### PR TITLE
fix(release): create GitHub Release before uploading binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  prepare-release:
+    # Creates the GitHub Release object before the binary jobs try to
+    # attach archives to it. taiki-e/upload-rust-binary-action does NOT
+    # create releases on tag-push events — it expects one to already
+    # exist, otherwise it retries 10× then fails with "release not found".
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create or reuse the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; reusing."
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
+
   publish:
     name: Publish to crates.io
+    needs: prepare-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +86,7 @@ jobs:
 
   release-binaries:
     name: Build & upload (${{ matrix.target }})
-    needs: publish
+    needs: [prepare-release, publish]
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
## Why
v0.1.2 (the first release with the prebuilt-binary pipeline from #23) exposed a gap: \`taiki-e/upload-rust-binary-action\` does **not** create a GitHub Release on tag-push events. It expects one to already exist and retries 10× with \"release not found\" before failing.

Result on the v0.1.2 run:
- \`publish\` to crates.io ✅
- All three \`release-binaries\` jobs ❌ (\"release not found\" loop)

## Fix
New \`prepare-release\` job that runs first and creates (or reuses) the GitHub Release via \`gh release create --generate-notes\`:

\`\`\`yaml
jobs:
  prepare-release:
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - uses: actions/checkout@v4
      - run: |
          if gh release view \"\$TAG\" >/dev/null 2>&1; then
            echo \"Release \$TAG already exists; reusing.\"
          else
            gh release create \"\$TAG\" --title \"\$TAG\" --generate-notes
          fi

  publish:
    needs: prepare-release
    ...

  release-binaries:
    needs: [prepare-release, publish]
    ...
\`\`\`

Idempotent: if a Release already exists (e.g. someone created it manually for recovery), the step is a no-op. Both publish and binaries now depend on it, so the Release object is guaranteed before any attachment is attempted.

## Recovery for v0.1.2
The v0.1.2 Release has been created manually so that re-running the failed binary jobs succeeds. The crate itself is already on crates.io, so consumers using \`cargo install\` keep working; only \`cargo binstall\` would have fallen back to source build until the binaries land.

## Test plan
- [ ] CI green on this PR.
- [ ] Next release tag (v0.1.3) runs all three jobs cleanly without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)