### PR TITLE
fix(tui): preserve build record after dashboard exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-05-03
+
+### Fixed
+- `cargo-chronoscope watch`: pressing any key on the post-build dashboard no longer marks the run as interrupted. The dismiss keypress was sharing the same `CancellationToken` as the Ctrl-C handler, so it routed through `finalize_or_discard`'s "interrupted" branch and deleted the freshly recorded build. Fixes [#33](https://github.com/ymw0407/cargo-chronoscope/issues/33).
+
 ## [0.1.5] - 2026-05-03
 
 ### Changed
@@ -60,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQLite-backed history at `<workspace>/.cargo-chronoscope/history.db`.
 - Anomaly classifier (mean ± 2σ) and ratatui dashboard.
 
-[Unreleased]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/ymw0407/cargo-chronoscope/compare/v0.1.2...v0.1.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-chronoscope"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -36,6 +36,12 @@ use crate::tui::state::TuiState;
 /// Block in the TUI's keyboard loop until the user presses any key, or
 /// `cancel` is fired. Used after the build finishes so the final dashboard
 /// stays on screen instead of vanishing the moment the alt screen is left.
+///
+/// **Important:** this function must NOT cancel the shared `CancellationToken`
+/// on key press. The build is already finished by the time we wait here, and
+/// firing the token would route the run through `finalize_or_discard`'s
+/// "interrupted" branch, deleting the just-recorded build. The outer TUI loop
+/// already has an explicit `break` after this call, so no signal is needed.
 fn wait_for_exit_key(cancel: &CancellationToken) -> anyhow::Result<()> {
     loop {
         if cancel.is_cancelled() {
@@ -43,7 +49,6 @@ fn wait_for_exit_key(cancel: &CancellationToken) -> anyhow::Result<()> {
         }
         if crossterm::event::poll(Duration::from_millis(100))? {
             if let Event::Key(_) = crossterm::event::read()? {
-                cancel.cancel();
                 return Ok(());
             }
         }


### PR DESCRIPTION
Closes #33

## Summary
- `cargo-chronoscope watch` was deleting the freshly recorded build whenever the user pressed any key on the post-build dashboard. The dismiss keypress shared the same `CancellationToken` as the Ctrl-C-during-build handler, so it took the "interrupted" branch in `finalize_or_discard` and ran `repo.delete_build()`.
- Fix: stop firing `cancel.cancel()` in `wait_for_exit_key`. The outer TUI loop already has an explicit `break` after the call, and the broker / persister tasks have already exited naturally because the supervisor closed the event stream when the build finished — no signal is needed for graceful shutdown at that point.
- The Ctrl-C-during-build path (the actual reason the token exists) is unaffected: that runs through the main tick loop's key handler, which still cancels intentionally.

Bundles a 0.1.6 version bump and a CHANGELOG entry so the fix can ship as a hotfix release immediately on merge.

## Files changed
- `src/tui/mod.rs` — remove the stray cancel call; add a doc-comment paragraph explaining why the function must not cancel.
- `Cargo.toml` / `Cargo.lock` — 0.1.5 → 0.1.6.
- `CHANGELOG.md` — 0.1.6 entry.

## Test plan
- [x] `cargo fmt --check` passes.
- [x] `cargo clippy --all-targets -- -D warnings` passes.
- [x] `cargo test` passes (137 tests).
- [x] Manual: ran `cargo install --path . --locked --force` then `cargo-chronoscope watch` in this repo, pressed Enter on the final dashboard, confirmed `Build #N recorded.` and `cargo-chronoscope ls` shows the row.
- [ ] CI green on this PR.
- [ ] After merge, tag `v0.1.6` and let the release workflow publish to crates.io / GitHub Marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)