### PR TITLE
docs(readme): refresh Status section with current platform coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,21 +297,29 @@ transaction).
 
 You can query the database directly with `sqlite3 .cargo-chronoscope/history.db`
 if you want.
-
 ## Status
 
-Active development. The CLI surface above is what works today; expect new
-flags and formats as the tool evolves.
+This project is under active development.
+
+Current release CI builds and tests prebuilt binaries for:
+
+- Linux (x86_64-unknown-linux-gnu)
+- macOS (x86_64-apple-darwin)
+- macOS (aarch64-apple-darwin)
+
+Windows support is currently untested.
+
+The release workflow automatically generates binaries on each tagged release.
+Latest builds and artifacts can be found in the GitHub Releases section.
 
 Known gaps:
 
-- Windows is not yet tested in CI (Linux x86_64 and macOS x86_64/aarch64 are exercised by the release workflow; primary development happens on macOS aarch64).
-- `cargo --timings` integration is not yet exposed (cargo's own per-crate
-  timing report could feed the same database).
-- `anomaly` thresholds are not configurable from the CLI (hardcoded to 2σ).
+- Windows is not yet validated in CI
+- Some experimental CLI features may change between releases
+- Performance analysis modules are still evolving
 
-See [issues](https://github.com/ymw0407/cargo-chronoscope/issues) for the
-prioritised list.
+See [issues](https://github.com/ymw0407/cargo-chronoscope/issues) for planned improvements.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ transaction).
 
 You can query the database directly with `sqlite3 .cargo-chronoscope/history.db`
 if you want.
+
 ## Status
 
 This project is under active development.
@@ -307,19 +308,20 @@ Current release CI builds and tests prebuilt binaries for:
 - macOS (x86_64-apple-darwin)
 - macOS (aarch64-apple-darwin)
 
-Windows support is currently untested.
-
-The release workflow automatically generates binaries on each tagged release.
-Latest builds and artifacts can be found in the GitHub Releases section.
+Windows support is currently untested. See the
+[release workflow](.github/workflows/release.yml) and the
+[Releases page](https://github.com/ymw0407/cargo-chronoscope/releases) for
+the latest builds and artifacts.
 
 Known gaps:
 
-- Windows is not yet validated in CI
-- Some experimental CLI features may change between releases
-- Performance analysis modules are still evolving
+- Windows is not yet validated in CI.
+- `cargo --timings` integration is not yet exposed (cargo's own per-crate
+  timing report could feed the same database).
+- `anomaly` thresholds are not configurable from the CLI (hardcoded to 2σ).
 
-See [issues](https://github.com/ymw0407/cargo-chronoscope/issues) for planned improvements.
-
+See [issues](https://github.com/ymw0407/cargo-chronoscope/issues) for the
+prioritised list.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Updated project status and known gaps in README to better reflect current platform coverage and limitations.

## Type of change
- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code change with no behavioural difference
- [x] docs: documentation only
- [ ] chore: build, CI, dependencies, or other miscellany

## Related issue
Closes #39

## Affected modules
- [x] docs / README

## Notes for reviewers
Updated the README "Status" section to accurately reflect:
- Linux x86_64 and macOS x86_64/aarch64 support via release CI
- Windows is still untested
- Added link to release workflow for verification