### PR TITLE
[Chore] Fix .gitignore typo (.cargo-chrono -> .cargo-chronoscope)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 **/*.rs.bk
 
 # cargo-chrono local data
-.cargo-chrono/
+.cargo-chronoscope/
 
 # IDE
 .idea/


### PR DESCRIPTION
## Summary

Fixes `.gitignore` typo: `.cargo-chrono` -> `.cargo-chronoscope`

Closes ymw0407/cargo-chronoscope#35