### PR TITLE
chore(ci): bump action default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ jobs:
 
       - uses: ymw0407/cargo-chronoscope@action-v1
         with:
-          version: '0.1.4'          # crate version pulled from crates.io
+          version: '0.1.6'          # crate version pulled from crates.io
           cargo-args: '--release'   # forwarded to `cargo build`
           baseline-ref: 'main'
           comment: 'true'
@@ -215,15 +215,15 @@ Release tags follow two namespaces:
 
 | Tag | Purpose | Example pin |
 |---|---|---|
-| `vX.Y.Z`         | Binary release on crates.io. Used by `cargo install`. | `cargo install cargo-chronoscope --version 0.1.4` |
+| `vX.Y.Z`         | Binary release on crates.io. Used by `cargo install`. | `cargo install cargo-chronoscope --version 0.1.6` |
 | `action-vN`      | Moving major tag for the GitHub Action — points at the latest backward-compatible release. | `uses: ymw0407/cargo-chronoscope@action-v1` |
-| `action-vN.M.P`  | Immutable point release for the action.              | `uses: ymw0407/cargo-chronoscope@action-v1.0.0` |
+| `action-vN.M.P`  | Immutable point release for the action.              | `uses: ymw0407/cargo-chronoscope@action-v1.0.2` |
 
 Action inputs:
 
 | Input              | Default            | Description |
 |--------------------|--------------------|-------------|
-| `version`          | `0.1.1`            | crate version installed via `cargo install`. Use a concrete version for reproducibility, or `latest`. |
+| `version`          | `0.1.6`            | crate version installed via `cargo install`. Use a concrete version for reproducibility, or `latest`. |
 | `cargo-args`       | `--release`        | Forwarded verbatim to `cargo build`. |
 | `baseline-ref`     | `main`             | Branch whose cached DB is the baseline. Only pushes to this ref update the cache. |
 | `cache-key-prefix` | `chronoscope-db`   | Prefix for the GitHub Actions cache key. |

--- a/action.yml
+++ b/action.yml
@@ -27,11 +27,11 @@ inputs:
   version:
     description: >-
       cargo-chronoscope version to install. Pinning a concrete version
-      (e.g. `0.1.1`) gives reproducible runs; `latest` always pulls the
-      newest published crate. Defaults to the oldest version that
-      supports the `--format json` parsing path used internally.
+      (e.g. `0.1.6`) gives reproducible runs; `latest` always pulls the
+      newest published crate. Defaults to the current recommended action
+      version.
     required: false
-    default: '0.1.1'
+    default: '0.1.6'
   cargo-args:
     description: >-
       Arguments forwarded verbatim to `cargo build` via


### PR DESCRIPTION
## Summary

Bumps the GitHub Action `version` input default from `0.1.1` to `0.1.6` and keeps the README action examples in sync.

## Type of change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code change with no behavioural difference
- [ ] test: tests only
- [ ] docs: documentation only
- [x] chore: build, CI, dependencies, or other miscellany

## Related issue

Closes #36

## Affected modules

- [ ] `model/` (shared types)
- [ ] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [ ] `main.rs`
- [x] docs / CI / config

## Tests

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Unit tests added for new behaviour
- [x] Manual test performed (describe below if applicable):

Ran `git diff --check` and verified no stale `0.1.1`, `0.1.4`, or `action-v1.0.0` references remain in `README.md` or `action.yml`.

## Notes for reviewers

This only updates action metadata and README examples. Retagging `action-v1` and creating `action-v1.0.2` will need to be done by a maintainer after merge.