### PR TITLE
fix(ci): post perf sticky comment on fork PRs via workflow_run

### DIFF
--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -1,15 +1,20 @@
 name: Build performance
 
 # Records this repo's own `cargo build` with cargo-chronoscope and diffs it
-# against the previous run. The history database is cached across runs, with
-# main acting as the canonical baseline:
-#   - every run restores the most recent main DB
-#   - only `push` to main writes back to the cache
-# The diff is appended to the workflow step summary, and on pull_request runs
-# it is uploaded as an artifact for the `Build performance comment` workflow
-# (.github/workflows/perf-comment.yml) to post as a sticky comment via a
-# `workflow_run` trigger. That two-workflow split is what lets fork PRs get
-# a sticky comment despite GitHub forcing forked-PR tokens to read-only.
+# against the previous run, producing the sticky perf-diff comment for
+# every PR.
+#
+# This workflow is a thin caller of the in-repo composite action
+# (`uses: ./`) so the record/diff/artifact-upload logic lives in exactly
+# one place — action.yml. The comment itself is posted by the sibling
+# perf-comment.yml on workflow_run completion, which is what makes it
+# work for forked PRs (those get a read-only token here).
+#
+# Trade-off: the chronoscope binary used to measure builds is the version
+# pinned in action.yml, installed from crates.io via cargo-binstall. PRs
+# that change the diff/report format will only show that change in CI
+# after the next crates.io release. In exchange, this workflow stays in
+# lockstep with the action that downstream users actually consume.
 
 on:
   push:
@@ -28,110 +33,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
 
-      # Cache scoped to the *install* target directory only.
-      #
-      # The chronoscope binary built from this PR's source must be cached
-      # to keep CI fast, but the workspace's own `./target/` MUST stay
-      # cold so the `record` step measures a full release build with
-      # meaningful per-crate timings. We solve this by giving the install
-      # step a separate target dir (/tmp/install-target via CARGO_TARGET_DIR
-      # below) and pointing rust-cache at that dir alone.
-      #
-      # `save-if` restricts cache writes to baseline-branch pushes so PR
-      # runs never overwrite the canonical install cache.
-      - name: Cache install artifacts
-        uses: Swatinem/rust-cache@v2
+      - uses: ./
         with:
-          workspaces: '. -> /tmp/install-target'
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
-      - name: Restore chronoscope history
-        uses: actions/cache/restore@v5
-        with:
-          path: .cargo-chronoscope/history.db
-          key: chronoscope-db-${{ github.sha }}
-          restore-keys: |
-            chronoscope-db-
-
-      - name: Install cargo-chronoscope (from this repo's source)
-        # Build the binary from the checked-out source rather than crates.io
-        # so CI exercises the version under review. `--locked` honours
-        # Cargo.lock. CARGO_TARGET_DIR sends compiled artifacts to a
-        # scratch path so the workspace's ./target/ remains untouched —
-        # see the rust-cache step above for why this matters.
-        env:
-          CARGO_TARGET_DIR: /tmp/install-target
-        run: cargo install --path . --locked
-
-      - name: Record build
-        # ./target/ is empty, so this triggers a full cold release build
-        # and produces real per-crate timings for the diff.
-        run: cargo-chronoscope record -- --release
-
-      - name: Show recent builds
-        run: cargo-chronoscope ls --last 5
-
-      - name: Render performance report
-        # Writes the diff (or a "nothing to diff" notice for the first build)
-        # to perf-report.md. The next two steps consume that file: one appends
-        # to the workflow summary, and on PR runs another step uploads it as
-        # an artifact for perf-comment.yml to post.
-        run: |
-          set -euo pipefail
-          mapfile -t ids < <(cargo-chronoscope ls --last 2 \
-            | awk '/^#[0-9]+/ {gsub(/#/,"",$1); print $1}')
-          {
-            if [ "${#ids[@]}" -lt 2 ]; then
-              echo "## Build performance"
-              echo ""
-              echo "_Only one build recorded so far — nothing to diff._"
-            else
-              before="${ids[1]}"
-              after="${ids[0]}"
-              echo "## Build performance: #${before} → #${after}"
-              echo ""
-              echo '```'
-              cargo-chronoscope diff "$before" "$after"
-              echo '```'
-            fi
-          } > perf-report.md
-          cat perf-report.md
-
-      - name: Append report to step summary
-        run: cat perf-report.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Stage perf artifact for the comment workflow
-        # On PR runs we hand perf-report.md and the PR number off to
-        # perf-comment.yml via an artifact. That sibling workflow runs in
-        # the base-repo context (workflow_run trigger), where the GitHub
-        # token has pull-requests: write even for forked-PR runs — which
-        # this workflow's token does not.
-        if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-          mkdir -p perf-artifact
-          cp perf-report.md perf-artifact/perf-report.md
-          # PR number is read by perf-comment.yml and validated as a
-          # positive integer there before being interpolated into any API
-          # call, so a tampered artifact cannot inject shell or URL fragments.
-          printf '%s\n' "${{ github.event.pull_request.number }}" \
-            > perf-artifact/pr-number.txt
-
-      - name: Upload perf artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: perf-report
-          path: perf-artifact/
-          retention-days: 7
-          if-no-files-found: error
-
-      - name: Save chronoscope history
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: .cargo-chronoscope/history.db
-          key: chronoscope-db-${{ github.sha }}
+          cargo-args: '--release'
+          baseline-ref: 'main'
+          # Comment is posted by perf-comment.yml, not in this job — the
+          # in-step path silently fails on forked-PR runs.
+          comment: 'false'
+          upload-artifact: 'true'

--- a/.github/workflows/build-perf.yml
+++ b/.github/workflows/build-perf.yml
@@ -6,7 +6,10 @@ name: Build performance
 #   - every run restores the most recent main DB
 #   - only `push` to main writes back to the cache
 # The diff is appended to the workflow step summary, and on pull_request runs
-# it is also posted as a sticky comment on the PR (idempotently updated).
+# it is uploaded as an artifact for the `Build performance comment` workflow
+# (.github/workflows/perf-comment.yml) to post as a sticky comment via a
+# `workflow_run` trigger. That two-workflow split is what lets fork PRs get
+# a sticky comment despite GitHub forcing forked-PR tokens to read-only.
 
 on:
   push:
@@ -23,10 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Required to post / edit PR comments. Forked-PR tokens are still
-      # read-only regardless of this block, so the comment step uses
-      # continue-on-error to avoid failing the run when posting is denied.
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -78,7 +77,8 @@ jobs:
       - name: Render performance report
         # Writes the diff (or a "nothing to diff" notice for the first build)
         # to perf-report.md. The next two steps consume that file: one appends
-        # to the workflow summary, the other posts a PR comment.
+        # to the workflow summary, and on PR runs another step uploads it as
+        # an artifact for perf-comment.yml to post.
         run: |
           set -euo pipefail
           mapfile -t ids < <(cargo-chronoscope ls --last 2 \
@@ -103,35 +103,31 @@ jobs:
       - name: Append report to step summary
         run: cat perf-report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post / update PR comment
-        # Sticky comment: find the previous bot comment by hidden marker and
-        # PATCH it; otherwise create a new one. Forked-PR runs only have a
-        # read-only token, hence continue-on-error.
+      - name: Stage perf artifact for the comment workflow
+        # On PR runs we hand perf-report.md and the PR number off to
+        # perf-comment.yml via an artifact. That sibling workflow runs in
+        # the base-repo context (workflow_run trigger), where the GitHub
+        # token has pull-requests: write even for forked-PR runs — which
+        # this workflow's token does not.
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          marker='<!-- chronoscope-perf-comment -->'
-          { echo "$marker"; echo ""; cat perf-report.md; } > comment.md
+          mkdir -p perf-artifact
+          cp perf-report.md perf-artifact/perf-report.md
+          # PR number is read by perf-comment.yml and validated as a
+          # positive integer there before being interpolated into any API
+          # call, so a tampered artifact cannot inject shell or URL fragments.
+          printf '%s\n' "${{ github.event.pull_request.number }}" \
+            > perf-artifact/pr-number.txt
 
-          existing_id=$(gh api \
-            "repos/${REPO}/issues/${PR}/comments" \
-            --paginate \
-            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
-
-          if [ -n "$existing_id" ]; then
-            jq -Rs '{body: .}' comment.md \
-              | gh api "repos/${REPO}/issues/comments/${existing_id}" \
-                  -X PATCH --input -
-            echo "Updated existing PR comment ${existing_id}."
-          else
-            gh pr comment "$PR" --body-file comment.md
-            echo "Created new PR comment."
-          fi
+      - name: Upload perf artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-report
+          path: perf-artifact/
+          retention-days: 7
+          if-no-files-found: error
 
       - name: Save chronoscope history
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -1,0 +1,80 @@
+name: Build performance comment
+
+# Posts (or updates) the sticky perf-diff comment on a pull request.
+#
+# Why a separate workflow:
+# `build-perf.yml` runs on the `pull_request` event. For PRs from forks,
+# GitHub forces the workflow's GITHUB_TOKEN to be read-only regardless of
+# the workflow's own `permissions:` block, so it cannot create or edit
+# comments. This workflow runs on `workflow_run`, which always executes
+# in the base-repo context with a token that honours `permissions:` —
+# including for fork PRs. It downloads the perf-report artifact produced
+# by the upstream run and posts/updates the sticky comment from there.
+#
+# Trust model:
+# The artifact is produced by code that may originate from a fork. We never
+# eval, source, or shell-interpret its contents; perf-report.md is read
+# verbatim into the GitHub API request body, and pr-number.txt is parsed
+# strictly as a positive integer before being interpolated anywhere.
+
+on:
+  workflow_run:
+    workflows: ["Build performance"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post / update PR perf comment
+    runs-on: ubuntu-latest
+    # Skip pushes to main and any non-success runs. Cancelled or failed
+    # build-perf runs have nothing to report.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download perf artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./perf-artifact
+
+      - name: Read and validate PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          raw=$(cat ./perf-artifact/pr-number.txt | tr -d '[:space:]')
+          if ! [[ "$raw" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Refusing to use untrusted PR number from artifact: '$raw'" >&2
+            exit 1
+          fi
+          echo "number=$raw" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker='<!-- chronoscope-perf-comment -->'
+          { echo "$marker"; echo ""; cat ./perf-artifact/perf-report.md; } > comment.md
+
+          existing_id=$(gh api \
+            "repos/${REPO}/issues/${PR}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+
+          if [ -n "$existing_id" ]; then
+            jq -Rs '{body: .}' comment.md \
+              | gh api "repos/${REPO}/issues/comments/${existing_id}" \
+                  -X PATCH --input -
+            echo "Updated existing PR comment ${existing_id}."
+          else
+            gh pr comment "$PR" --body-file comment.md --repo "$REPO"
+            echo "Created new PR comment."
+          fi

--- a/README.md
+++ b/README.md
@@ -184,7 +184,19 @@ baseline branch records a build and updates a cached history database;
 each pull request records a build and posts (or updates in place) a
 sticky comment with the diff against the baseline.
 
+### Recommended setup (works on PRs from forks)
+
+GitHub forces the `GITHUB_TOKEN` of any `pull_request` workflow run from
+a fork to be read-only, regardless of the workflow's `permissions:`
+block. A composite action cannot work around this from inside the same
+job, so to make the sticky comment land on fork PRs the report is
+uploaded as an artifact and a sibling workflow on `workflow_run` posts
+it from base-repo context.
+
+Drop both of these into `.github/workflows/`:
+
 ```yaml
+# .github/workflows/build-perf.yml
 name: Build performance
 
 on:
@@ -198,18 +210,76 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write          # required for sticky PR comments
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: ymw0407/cargo-chronoscope@action-v1
         with:
-          version: '0.1.6'          # crate version pulled from crates.io
-          cargo-args: '--release'   # forwarded to `cargo build`
+          version: '0.1.6'
+          cargo-args: '--release'
           baseline-ref: 'main'
-          comment: 'true'
+          comment: 'false'           # let the companion workflow post
+          upload-artifact: 'true'    # hand off the report as an artifact
 ```
+
+```yaml
+# .github/workflows/perf-comment.yml
+name: Build performance comment
+
+on:
+  workflow_run:
+    workflows: ["Build performance"]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: perf-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./perf-artifact
+      # See examples/ci/perf-comment.yml for the validation + posting steps.
+```
+
+The full companion (with PR-number validation and the sticky-comment
+posting logic) lives at
+[`examples/ci/perf-comment.yml`](examples/ci/perf-comment.yml). Both
+files are copy-pasteable as-is.
+
+### Simpler setup (single workflow, same-repo PRs only)
+
+If your repository never receives PRs from forks, you can skip the
+companion workflow and let the action post the comment directly:
+
+```yaml
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write          # required for the in-step comment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ymw0407/cargo-chronoscope@action-v1
+        with:
+          version: '0.1.6'
+          comment: 'true'           # action posts the comment itself
+```
+
+This will silently skip the comment step on any forked-PR run.
+
+### Tags
 
 Release tags follow two namespaces:
 
@@ -219,7 +289,7 @@ Release tags follow two namespaces:
 | `action-vN`      | Moving major tag for the GitHub Action — points at the latest backward-compatible release. | `uses: ymw0407/cargo-chronoscope@action-v1` |
 | `action-vN.M.P`  | Immutable point release for the action.              | `uses: ymw0407/cargo-chronoscope@action-v1.0.2` |
 
-Action inputs:
+### Action inputs
 
 | Input              | Default            | Description |
 |--------------------|--------------------|-------------|
@@ -227,10 +297,11 @@ Action inputs:
 | `cargo-args`       | `--release`        | Forwarded verbatim to `cargo build`. |
 | `baseline-ref`     | `main`             | Branch whose cached DB is the baseline. Only pushes to this ref update the cache. |
 | `cache-key-prefix` | `chronoscope-db`   | Prefix for the GitHub Actions cache key. |
-| `comment`          | `true`             | Post or update a sticky PR comment with the diff. |
-| `github-token`     | `${{ github.token }}` | Token used for the comment step. |
+| `comment`          | `true`             | Post or update a sticky PR comment from inside this job. Silently fails on fork PRs — see the recommended setup above. |
+| `upload-artifact`  | `false`            | Upload the report and PR number as an artifact named `perf-report` for the companion `workflow_run` workflow. |
+| `github-token`     | `${{ github.token }}` | Token used for the in-step comment path. |
 
-Action outputs:
+### Action outputs
 
 | Output | Description |
 |---|---|
@@ -241,8 +312,9 @@ Action outputs:
 > directory short-circuits compilation and erases the per-crate timing
 > signal that chronoscope measures.
 
-A copy-pasteable reference workflow lives at
-[`examples/ci/build-perf.yml`](examples/ci/build-perf.yml).
+Copy-pasteable reference workflows live at
+[`examples/ci/build-perf.yml`](examples/ci/build-perf.yml) and
+[`examples/ci/perf-comment.yml`](examples/ci/perf-comment.yml).
 
 ## How it works
 

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,21 @@ branding:
 #   2. Install cargo-chronoscope (from crates.io, with `--locked`).
 #   3. Run `cargo-chronoscope record` against the project under test.
 #   4. Render a Markdown diff (current build vs. previous build) into
-#      $GITHUB_STEP_SUMMARY, and -- on pull_request runs -- as a sticky
-#      PR comment identified by a hidden marker so it updates in place.
+#      $GITHUB_STEP_SUMMARY, and -- on pull_request runs -- either post
+#      it as a sticky comment (`comment: true`) or upload it as an
+#      artifact for a workflow_run-triggered companion to post
+#      (`upload-artifact: true`).
 #   5. Save the updated DB back to the cache, but only on baseline-branch
 #      pushes, so PR runs never overwrite the baseline.
+#
+# Sticky comments and forked PRs:
+# GitHub forces forked-PR runs to use a read-only GITHUB_TOKEN regardless
+# of the workflow's `permissions:` block, so the in-step `comment: true`
+# path silently fails on fork PRs. To get sticky comments on fork PRs,
+# set `comment: false` and `upload-artifact: true`, then pair this action
+# with the workflow at examples/ci/perf-comment.yml in your repository.
+# That companion runs on `workflow_run`, which executes in base-repo
+# context with a write-capable token even for forked-PR upstream runs.
 #
 # The action is intentionally `composite` (not Docker / JS) so it inherits
 # the calling workflow's Rust toolchain and its rust-cache state. The
@@ -51,11 +62,23 @@ inputs:
     default: 'chronoscope-db'
   comment:
     description: >-
-      Post (or update) a sticky PR comment with the diff. `true` or
-      `false`. Forked-PR runs receive a read-only token, so posting may
-      fail silently — the workflow itself continues regardless.
+      Post (or update) a sticky PR comment with the diff from inside this
+      action's job. `true` or `false`. Works for same-repo PRs but
+      silently fails on forked-PR runs because GitHub gives those runs a
+      read-only token. To support fork PRs, set this to `false` and use
+      `upload-artifact: true` together with the perf-comment.yml
+      companion workflow — see examples/ci/.
     required: false
     default: 'true'
+  upload-artifact:
+    description: >-
+      Upload perf-report.md and the PR number as a GitHub Actions
+      artifact (named `perf-report`) so a workflow_run-triggered
+      companion workflow can post the sticky comment from base-repo
+      context. Use this for repos that accept fork PRs. Reference
+      companion at examples/ci/perf-comment.yml.
+    required: false
+    default: 'false'
   github-token:
     description: >-
       Token used to post PR comments. Defaults to ${{ github.token }}.
@@ -176,6 +199,29 @@ runs:
           gh pr comment "$PR" --body-file comment.md
           echo "Created new PR comment."
         fi
+
+    - name: Stage perf artifact for the companion workflow
+      if: inputs.upload-artifact == 'true' && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p perf-artifact
+        cp perf-report.md perf-artifact/perf-report.md
+        # The companion workflow (examples/ci/perf-comment.yml) reads
+        # pr-number.txt and validates it as a positive integer before
+        # interpolating it anywhere, so a tampered artifact cannot inject
+        # shell or URL fragments.
+        printf '%s\n' "${{ github.event.pull_request.number }}" \
+          > perf-artifact/pr-number.txt
+
+    - name: Upload perf artifact
+      if: inputs.upload-artifact == 'true' && github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: perf-report
+        path: perf-artifact/
+        retention-days: 7
+        if-no-files-found: error
 
     - name: Save chronoscope history
       if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', inputs.baseline-ref)

--- a/action.yml
+++ b/action.yml
@@ -81,8 +81,9 @@ inputs:
     default: 'false'
   github-token:
     description: >-
-      Token used to post PR comments. Defaults to ${{ github.token }}.
-      Only used when `comment` is `true` and the event is a pull_request.
+      Token used to post PR comments. Defaults to the workflow's
+      automatic GITHUB_TOKEN. Only used when `comment` is `true` and
+      the event is a pull_request.
     required: false
     default: ${{ github.token }}
 

--- a/examples/ci/build-perf.yml
+++ b/examples/ci/build-perf.yml
@@ -1,10 +1,22 @@
 # Example: how a downstream Rust project would adopt the cargo-chronoscope
 # composite action.
 #
-# Drop a copy of this file at .github/workflows/build-perf.yml in any Rust
-# repository. The action measures cargo build performance, caches the
-# history DB with `main` as the canonical baseline, and posts a sticky
-# diff comment on each pull request.
+# This example uses the recommended two-workflow pattern: this file runs
+# on `pull_request` and uploads the perf report as an artifact, then the
+# companion at examples/ci/perf-comment.yml runs on `workflow_run` and
+# posts the sticky PR comment. The split is what makes the sticky comment
+# work for forked-PR runs — GitHub forces the GITHUB_TOKEN of any
+# pull_request run from a fork to be read-only, so the comment must be
+# posted from a workflow_run-triggered job (which executes in base-repo
+# context with a write-capable token).
+#
+# Drop a copy of this file at .github/workflows/build-perf.yml AND a
+# copy of examples/ci/perf-comment.yml at .github/workflows/perf-comment.yml.
+#
+# If your repository never receives PRs from forks, you can omit the
+# companion workflow and instead set `comment: 'true'` and
+# `upload-artifact: 'false'` below — the action will then post the sticky
+# comment itself. The job will also need `pull-requests: write` permission.
 #
 # Caller responsibilities:
 #   - Set up the Rust toolchain (the action does NOT do this for you, so it
@@ -24,8 +36,9 @@ jobs:
   measure:
     runs-on: ubuntu-latest
     permissions:
+      # Reduced from `pull-requests: write` because this workflow no
+      # longer posts the comment itself; perf-comment.yml does.
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -34,12 +47,15 @@ jobs:
         with:
           # cargo-chronoscope binary version pulled from crates.io. Pin a
           # concrete version for reproducibility, or use `latest`.
-          version: '0.1.4'
+          version: '0.1.6'
           # Forwarded to `cargo build`. Default is --release; pass an empty
           # string for a debug build.
           cargo-args: '--release'
           # Branch whose DB is the baseline. Only pushes to this ref will
           # write back to the cache.
           baseline-ref: 'main'
-          # Sticky PR comment is on by default; set to 'false' to disable.
-          comment: 'true'
+          # Comment is posted by perf-comment.yml, not by the action's
+          # own in-step path — the latter would silently fail on fork PRs.
+          comment: 'false'
+          # Hand perf-report.md and the PR number off to perf-comment.yml.
+          upload-artifact: 'true'

--- a/examples/ci/perf-comment.yml
+++ b/examples/ci/perf-comment.yml
@@ -1,0 +1,82 @@
+# Companion workflow for examples/ci/build-perf.yml.
+#
+# Posts (or updates) the sticky perf-diff comment on a pull request. Runs
+# on `workflow_run`, which always executes in the base-repo context with
+# a token that honours the workflow's `permissions:` block — including
+# for upstream runs that originated from a forked PR. That's what makes
+# the sticky comment land on fork PRs at all; GitHub forces forked-PR
+# `pull_request` runs to use a read-only token regardless of permissions.
+#
+# Drop this file at .github/workflows/perf-comment.yml in the same repo
+# that uses examples/ci/build-perf.yml. The two are paired by the
+# `workflows: ["Build performance"]` filter below — if you rename the
+# upstream workflow, update that name accordingly.
+#
+# Trust model:
+# The artifact is produced by code that may originate from a fork. We
+# never eval, source, or shell-interpret its contents; perf-report.md is
+# read verbatim into the GitHub API request body, and pr-number.txt is
+# parsed strictly as a positive integer before being interpolated anywhere.
+
+name: Build performance comment
+
+on:
+  workflow_run:
+    workflows: ["Build performance"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post / update PR perf comment
+    runs-on: ubuntu-latest
+    # Skip pushes to main and any non-success runs.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download perf artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./perf-artifact
+
+      - name: Read and validate PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          raw=$(cat ./perf-artifact/pr-number.txt | tr -d '[:space:]')
+          if ! [[ "$raw" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Refusing to use untrusted PR number from artifact: '$raw'" >&2
+            exit 1
+          fi
+          echo "number=$raw" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker='<!-- chronoscope-perf-comment -->'
+          { echo "$marker"; echo ""; cat ./perf-artifact/perf-report.md; } > comment.md
+
+          existing_id=$(gh api \
+            "repos/${REPO}/issues/${PR}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+
+          if [ -n "$existing_id" ]; then
+            jq -Rs '{body: .}' comment.md \
+              | gh api "repos/${REPO}/issues/comments/${existing_id}" \
+                  -X PATCH --input -
+            echo "Updated existing PR comment ${existing_id}."
+          else
+            gh pr comment "$PR" --body-file comment.md --repo "$REPO"
+            echo "Created new PR comment."
+          fi


### PR DESCRIPTION
## Summary

Fixes the sticky perf-diff comment for **fork PRs** at two levels:

1. **This repo's own CI** — replaces the in-step comment posting in `.github/workflows/build-perf.yml` with an artifact upload, and adds a new `.github/workflows/perf-comment.yml` that runs on `workflow_run` to post the sticky from base-repo context.
2. **The published composite action and its example workflows** — extends `action.yml` with an `upload-artifact` input, rewrites `examples/ci/build-perf.yml` to the two-workflow pattern, adds `examples/ci/perf-comment.yml`, and updates the README so downstream users can also get sticky comments on fork PRs.

GitHub forces the `GITHUB_TOKEN` of any `pull_request` workflow run from a fork to be read-only, regardless of `permissions:`. That's why the previous in-step comment path silently failed on fork PRs (#54, #55) — and why other people adopting our action would hit the same wall. The standard fix is splitting comment posting into a `workflow_run`-triggered companion that runs in base-repo context with a write-capable token.

## What ships in this PR

| File | Change |
|---|---|
| `.github/workflows/build-perf.yml` | In-step comment removed; uploads `perf-report` artifact instead. Permissions trimmed to `contents: read`. |
| `.github/workflows/perf-comment.yml` | **New.** `workflow_run` companion that posts/updates the sticky for this repo. |
| `action.yml` | New `upload-artifact` input; expanded header + `comment` description to explain the fork-PR limitation. |
| `examples/ci/build-perf.yml` | Updated to use `comment: false` + `upload-artifact: true`. Header explains the split and the simpler alternative. |
| `examples/ci/perf-comment.yml` | **New.** `workflow_run` companion that downstream users drop in. |
| `README.md` | "Use as a GitHub Action" section split into "Recommended" (two-workflow) and "Simpler" (single-workflow, same-repo PRs only). Inputs table updated. |

## Trust boundary

The artifact is produced by code that may originate from a fork. `perf-comment.yml` (both ours and the example) never evals, sources, or shell-interprets its contents — `perf-report.md` is read verbatim into the GitHub API request body (rendered as Markdown, not executed), and `pr-number.txt` is parsed strictly as `^[1-9][0-9]*$` before being interpolated into any URL.

## Type of change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] refactor: code change with no behavioural difference
- [ ] test: tests only
- [ ] docs: documentation only
- [ ] chore: build, CI, dependencies, or other miscellany

## Related issue

Closes #43

## Affected modules

- [ ] `model/` (shared types)
- [ ] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [ ] `main.rs`
- [x] docs / CI / config (also `action.yml` + `examples/ci/`)

## Tests

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Unit tests added for new behaviour
- [x] Manual test performed (describe below if applicable):

YAML-only PR; no Rust changes. Static review:

- `build-perf.yml` and `action.yml` retain the same record / diff / step-summary chain. Only the comment posting is replaced or supplemented.
- `perf-comment.yml` (both copies) mirrors the action's existing comment logic, swapping `github.event.pull_request.number` for the validated artifact value.

End-to-end behaviour can only be confirmed after merge — `workflow_run` triggers don't fire on PR runs of the workflow that defines them. The first PR opened against `main` after this lands will exercise the new path; if anything's off, follow-up patch.

## Notes for reviewers

- **Defaults preserved.** `comment` still defaults to `true` and `upload-artifact` defaults to `false`, so existing single-workflow users are unaffected. The two-workflow pattern is opt-in.
- **Permissions narrowed.** `build-perf.yml` (this repo) and the example `build-perf.yml` no longer request `pull-requests: write`, since they no longer post comments. The simpler same-repo example in the README still requests it because it does post in-step.
- **Artifact retention** is 7 days — long enough to debug a stuck `workflow_run`, short enough to not hoard storage.
- **Action retag.** After merge, `action-v1` will need to be force-retagged onto the merge commit so downstream users on `@action-v1` actually receive the new `upload-artifact` input. An `action-v1.0.3` immutable tag is the conventional companion.