### PR TITLE
chore(release): add Windows target and cross-compile macOS Intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,21 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          # macOS Intel: cross-compile from Apple Silicon (`macos-latest`)
+          # because macOS-13 Intel runners are no longer reliably allocated
+          # by GitHub Actions. The Apple Silicon SDK ships both
+          # architectures, so `cargo build --target x86_64-apple-darwin`
+          # succeeds on the arm64 runner once `rustup target add` has run.
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
+          # Windows MSVC build — the only path that lets users on Windows
+          # install via `cargo binstall cargo-chronoscope` (and thereby
+          # avoid the Smart App Control / WDAC blocks on cargo's temp
+          # build-script .exe files that source-builds hit).
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -109,10 +120,11 @@ jobs:
 
       - name: Build & attach archive to GitHub Release
         # Builds in `release` profile, packages the binary as
-        # `cargo-chronoscope-${TARGET}.tar.gz`, and uploads it to the
+        # `cargo-chronoscope-${TARGET}.{tar.gz,zip}`, and uploads it to the
         # GitHub Release that this tag created. cargo-binstall consumers
         # then resolve the archive via the [package.metadata.binstall]
-        # template in Cargo.toml.
+        # template in Cargo.toml. The action picks `.zip` for Windows
+        # targets and `.tar.gz` for Unix targets automatically.
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-chronoscope

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,15 @@ tempfile = "3"
 #   - {version} → crate version
 #   - {target}  → host triple (e.g. x86_64-unknown-linux-gnu)
 # Each archive contains the `cargo-chronoscope` binary at its root.
+#
+# Default is the Unix `.tar.gz` archive. Windows targets get an override
+# below because taiki-e/upload-rust-binary-action packages Windows builds
+# as `.zip` (containing a `.exe`).
 [package.metadata.binstall]
 pkg-url = "{repo}/releases/download/v{version}/{name}-{target}.tar.gz"
 bin-dir = "{bin}{binary-ext}"
 pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{repo}/releases/download/v{version}/{name}-{target}.zip"
+pkg-fmt = "zip"

--- a/README.md
+++ b/README.md
@@ -376,20 +376,27 @@ if you want.
 
 This project is under active development.
 
-Current release CI builds and tests prebuilt binaries for:
+Current release CI builds prebuilt binaries for:
 
 - Linux (x86_64-unknown-linux-gnu)
-- macOS (x86_64-apple-darwin)
+- macOS (x86_64-apple-darwin) — cross-compiled from the Apple Silicon runner
 - macOS (aarch64-apple-darwin)
+- Windows (x86_64-pc-windows-msvc)
 
-Windows support is currently untested. See the
-[release workflow](.github/workflows/release.yml) and the
-[Releases page](https://github.com/ymw0407/cargo-chronoscope/releases) for
-the latest builds and artifacts.
+`cargo binstall cargo-chronoscope` resolves the matching archive per
+host. On Windows specifically, the binstall path avoids the Smart App
+Control / WDAC blocks that source-builds (`cargo install`) hit when
+cargo's temporary build-script `.exe` files run from a sandbox-flagged
+location.
+
+See the [release workflow](.github/workflows/release.yml) and the
+[Releases page](https://github.com/ymw0407/cargo-chronoscope/releases)
+for the latest artifacts.
 
 Known gaps:
 
-- Windows is not yet validated in CI.
+- Windows is freshly added to the release matrix; first user-facing
+  `binstall` test happens at the next tagged release.
 - `cargo --timings` integration is not yet exposed (cargo's own per-crate
   timing report could feed the same database).
 - `anomaly` thresholds are not configurable from the CLI (hardcoded to 2σ).


### PR DESCRIPTION
## Summary

The 0.1.6 GitHub Release ended up with only Linux x86_64 and macOS aarch64 archives. Two issues converged:

1. The matrix used \`os: macos-13\` for \`x86_64-apple-darwin\`, but Intel macOS runners are no longer reliably allocated to public-repo jobs — the job has been silently failing.
2. There was no Windows target at all, so users on Windows have no \`cargo binstall\` path and fall back to source builds. Source builds on Windows hit the **Smart App Control / WDAC block on cargo's temp build-script .exe files** (\`os error 4551\`) and the install fails. This was just hit during local Windows verification of the demo.

Both fixed here.

## Changes

| File | Change |
|---|---|
| \`.github/workflows/release.yml\` | \`x86_64-apple-darwin\` moved to \`macos-latest\` (cross-compile from Apple Silicon — SDK ships both arches). \`aarch64-apple-darwin\` also moves to \`macos-latest\` for consistency. New \`x86_64-pc-windows-msvc\` row on \`windows-latest\`. |
| \`Cargo.toml\` | Added \`[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]\` so \`cargo binstall\` looks for the \`.zip\` archive on Windows (taiki-e action packages Windows builds as zip, Unix as tar.gz). |
| \`README.md\` | "Status" section refreshed: Windows in the release matrix; binstall is the recommended install path on Windows because it avoids the App Control source-build trap. |

## Verification

End-to-end behaviour can only be confirmed at the **next tag push** — the release workflow only fires on \`v*\` tags. The matrix update itself is YAML-only and statically reviewable; \`taiki-e/upload-rust-binary-action\` is a known-good action with documented Windows support.

If the new Windows job fails on first cut, follow-up patch.

## Type of change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] refactor
- [ ] test
- [ ] docs
- [x] chore (release / CI config)

## Affected modules

- [ ] \`model/\`
- [ ] \`cli/\`
- [ ] \`supervisor/\`
- [ ] \`parser/\`
- [ ] \`persist/\`
- [ ] \`diff/\`
- [ ] \`broker/\`
- [ ] \`anomaly/\`
- [ ] \`tui/\`
- [ ] \`main.rs\`
- [x] docs / CI / config (release.yml + Cargo.toml binstall metadata + README Status)

## Tests

- [ ] \`cargo test\`
- [ ] \`cargo clippy -- -D warnings\`
- [ ] Unit tests added
- [x] Manual test: \`Cargo.toml\` parses (no package validation errors via \`cargo metadata\` locally).

## Notes for reviewers

- **Why \`macos-latest\` for both Mac targets, not \`macos-14\`?** \`macos-latest\` currently aliases to \`macos-14\` and will track forward. The job is identical on both because the cross-compile target is set explicitly via \`rustup target add\`; we don't depend on the host arch.
- **Why not also add \`aarch64-pc-windows-msvc\`?** Snowdrop demand on ARM64 Windows is small for a Rust dev tool's primary audience. Easy follow-up if anyone asks for it.
- **No new tag is cut by this PR.** The next maintenance release (\`v0.1.7\`) will be the first to actually publish a Windows binary. Until then, Windows users still hit the source-build trap; documented honestly in the Status section.
- **Demo GIF in README (#62) is unaffected.** This PR only edits the Status section text below the GIF.