### PR TITLE
chore: v0.1.7 — Windows release matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-05-05
+
+### Added
+- Windows (`x86_64-pc-windows-msvc`) prebuilt binary in the release matrix, plus a `cargo-binstall` override so `cargo binstall cargo-chronoscope` resolves the `.zip` archive on Windows. This is the recommended install path on Windows because source builds via `cargo install` hit Smart App Control / WDAC blocks on cargo's temp build-script `.exe` files. ([#64](https://github.com/ymw0407/cargo-chronoscope/pull/64))
+- Forked-PR sticky perf-diff comments via a `workflow_run`-triggered companion workflow, both in this repo's CI and in the published action's example workflows. ([#59](https://github.com/ymw0407/cargo-chronoscope/pull/59))
+- README hero GIF showing the four-command flow on ripgrep. ([#62](https://github.com/ymw0407/cargo-chronoscope/pull/62))
+
+### Changed
+- macOS Intel (`x86_64-apple-darwin`) is now cross-compiled from the Apple Silicon runner because `macos-13` Intel runners are no longer reliably allocated. The `0.1.6` release silently dropped this archive; `0.1.7` restores it. ([#64](https://github.com/ymw0407/cargo-chronoscope/pull/64))
+- `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, and `CLAUDE.md` reframed the strict Integrator/Data/Realtime role-ownership rule as historical context; review routing now lives in `.github/CODEOWNERS` and external contributions to any module are explicitly welcome. ([9d4a91e](https://github.com/ymw0407/cargo-chronoscope/commit/9d4a91e))
+
+### Removed
+- The skeleton-phase `#![allow(dead_code)]` in `main.rs` and the items it was hiding: `BuildProfile::Custom`, `BuildEvent::CompilerMessage` + `MessageLevel`, `TuiState::set_build_id`, `BuildEvent::CompilationStarted.{kind, at}`, and the `kind` field on `ActiveCompilation` / `FinishedCompilation`. ([#61](https://github.com/ymw0407/cargo-chronoscope/pull/61))
+
 ## [0.1.6] - 2026-05-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-chronoscope"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps Cargo.toml + Cargo.lock to 0.1.7 ahead of cutting the v0.1.7 tag. First release that exercises the Windows + restored-macOS-Intel matrix added in #64.

## Changes since 0.1.6

| Area | Change | PR |
|---|---|---|
| Release | Windows (`x86_64-pc-windows-msvc`) prebuilt binary added; macOS Intel cross-compiled from Apple Silicon runner (the `macos-13` Intel runner had silently stopped allocating, dropping the `x86_64-apple-darwin` archive from 0.1.6) | #64 |
| CI | Forked-PR sticky perf-diff comments now work via `workflow_run` companion workflow, both in this repo and in the published action's example workflows | #59 |
| README | Hero GIF showing the four-command flow on ripgrep | #62 |
| Docs | Role-ownership rule reframed as historical context; CODEOWNERS for review routing; external contributions to any module welcome | direct push 9d4a91e |
| Refactor | Skeleton-phase `#![allow(dead_code)]` removed from `main.rs`; trimmed the items it was hiding (`BuildProfile::Custom`, `BuildEvent::CompilerMessage`, `TuiState::set_build_id`, `CompilationStarted.{kind, at}`, `Active`/`FinishedCompilation.kind`). `CrateCompilation` and `Baseline` kept as forward-compat slots under a single targeted, traced allow | #61 |

## Cutting the release

After this PR merges:

```bash
git fetch origin main
git checkout main && git pull
git tag v0.1.7
git push origin v0.1.7
```

The release workflow's verify step now passes (Cargo.toml === tag), and the four-target matrix produces:

- `cargo-chronoscope-x86_64-unknown-linux-gnu.tar.gz`
- `cargo-chronoscope-x86_64-apple-darwin.tar.gz`
- `cargo-chronoscope-aarch64-apple-darwin.tar.gz`
- `cargo-chronoscope-x86_64-pc-windows-msvc.zip` ← new

Plus an `action-v1` re-tag + `action-v1.0.4` immutable tag for downstream Action consumers (no Action input changed in this release, but the moving tag should advance to keep `version: '0.1.7'` reachable as the implicit default).

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] test
- [ ] docs
- [x] chore (release prep)

## Tests

- [ ] `cargo test`
- [ ] `cargo clippy -- -D warnings`
- [ ] Unit tests added
- [x] Manual: Cargo.toml + Cargo.lock version fields are in sync at 0.1.7. CI on this PR will exercise build/test on the new version.

## Notes for reviewers

- **CHANGELOG.md updated** in the same commit so the release-prep history is one-stop.
- **No code changes** in this PR; all functionality lands via the linked PRs already merged.
- **Stale tag cleanup**: an earlier attempt pushed `v0.1.7` on top of 0.1.6's Cargo.toml and the workflow correctly rejected it. That tag has been deleted; this PR clears the path for a clean re-tag.