### PR TITLE
feat(cli): add shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "ratatui",
  "rusqlite",
@@ -252,6 +253,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "1"
 async-trait = "0.1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 crossterm = "0.29"
 ratatui = "0.30"
 rusqlite = { version = "0.39", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ cargo install cargo-chronoscope
 
 This puts `cargo-chronoscope` on your `PATH` (typically `~/.cargo/bin`).
 
+### Shell completions
+
+Generate completion scripts with the `completions` subcommand:
+
+```bash
+cargo-chronoscope completions bash > ~/.local/share/bash-completion/completions/cargo-chronoscope
+cargo-chronoscope completions zsh > "${fpath[1]}/_cargo-chronoscope"
+cargo-chronoscope completions fish > ~/.config/fish/completions/cargo-chronoscope.fish
+cargo-chronoscope completions powershell > cargo-chronoscope.ps1
+cargo-chronoscope completions elvish > ~/.elvish/lib/cargo-chronoscope.elv
+```
+
 ### From source
 
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@
 pub mod json;
 
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 use crate::model::{Build, BuildDiff, BuildId, CrateChange, DurationChange};
 
@@ -67,6 +68,13 @@ pub enum Command {
         /// Output format.
         #[arg(long, value_enum, default_value_t = Format::Text)]
         format: Format,
+    },
+
+    /// Generate a shell completion script.
+    Completions {
+        /// Shell to generate completions for.
+        #[arg(value_enum)]
+        shell: Shell,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod tui;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use tokio_util::sync::CancellationToken;
 
 use crate::cli::{Cli, Command};
@@ -42,6 +42,12 @@ async fn main() -> anyhow::Result<()> {
         cancel_clone.cancel();
     });
 
+    if let Command::Completions { shell } = cli.command {
+        let mut cmd = Cli::command();
+        clap_complete::generate(shell, &mut cmd, "cargo-chronoscope", &mut std::io::stdout());
+        return Ok(());
+    }
+
     // Determine workspace directory and DB path.
     let workspace_dir = std::env::current_dir()?;
     let db_dir = workspace_dir.join(DB_DIR);
@@ -65,6 +71,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             cmd_diff(&db_path, before, after, format).await?;
         }
+        Command::Completions { .. } => unreachable!("handled before database setup"),
     }
 
     Ok(())

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+#[test]
+fn completions_generate_non_empty_scripts_for_supported_shells() {
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_cargo-chronoscope"))
+            .args(["completions", shell])
+            .output()
+            .unwrap_or_else(|err| panic!("failed to run completions for {shell}: {err}"));
+
+        assert!(
+            output.status.success(),
+            "completions {shell} exited with {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.stdout.is_empty(),
+            "completions {shell} produced empty stdout"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `completions <shell>` subcommand that prints shell completion scripts for bash, zsh, fish, PowerShell, and elvish.

## Type of change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code change with no behavioural difference
- [ ] test: tests only
- [ ] docs: documentation only
- [ ] chore: build, CI, dependencies, or other miscellany

## Related issue

Closes #68

## Affected modules

- [ ] `model/` (shared types)
- [x] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [ ] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [x] `main.rs`
- [x] docs / CI / config

## Tests

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Unit tests added for new behaviour
- [x] Manual test performed (describe below if applicable):

Ran:

```bash
cargo fmt --check
cargo test --all-targets
cargo clippy --all-targets -- -D warnings
```

## Notes for reviewers

The `completions` command returns before database setup, so generating completions does not create `.cargo-chronoscope` in the current directory.
