### PR TITLE
feat(cli): print build id at start

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::cli::{Cli, Command};
@@ -91,7 +93,14 @@ async fn cmd_record(
     };
     let event_rx = parser::run_parser(line_rx, config).await?;
 
-    let build_id = persist::run_persister(repo.clone(), event_rx).await?;
+    let (started_tx, started_rx) = oneshot::channel();
+    let mut persister = tokio::spawn(persist::run_persister(
+        repo.clone(),
+        event_rx,
+        Some(started_tx),
+    ));
+    announce_build_started(started_rx, &mut persister).await?;
+    let build_id = persister.await??;
     finalize_or_discard(repo, build_id, &cancel).await
 }
 
@@ -123,16 +132,41 @@ async fn cmd_watch(
 
     let repo_clone = repo.clone();
     let cancel_clone = cancel.clone();
+    let (started_tx, started_rx) = oneshot::channel();
 
-    // Run all tasks concurrently.
-    let (broker_result, persister_result, tui_result) = tokio::try_join!(
-        event_broker.publish_loop(event_rx, cancel.clone()),
-        persist::run_persister(repo_clone, persister_rx),
-        tui::run_tui(tui_rx, repo.clone(), cancel_clone),
-    )?;
+    let broker = tokio::spawn(event_broker.publish_loop(event_rx, cancel.clone()));
+    let mut persister = tokio::spawn(persist::run_persister(
+        repo_clone,
+        persister_rx,
+        Some(started_tx),
+    ));
 
-    let _ = (broker_result, tui_result);
-    finalize_or_discard(repo, persister_result, &cancel).await
+    announce_build_started(started_rx, &mut persister).await?;
+
+    let tui_result = tui::run_tui(tui_rx, repo.clone(), cancel_clone).await;
+    let broker_result = broker.await?;
+    let persister_result = persister.await?;
+
+    broker_result?;
+    tui_result?;
+    finalize_or_discard(repo, persister_result?, &cancel).await
+}
+
+async fn announce_build_started(
+    started_rx: oneshot::Receiver<BuildId>,
+    persister: &mut JoinHandle<anyhow::Result<BuildId>>,
+) -> anyhow::Result<()> {
+    tokio::select! {
+        id = started_rx => {
+            let id = id?;
+            println!("Recording build {}...", id);
+            Ok(())
+        }
+        result = persister => {
+            result??;
+            anyhow::bail!("build finished before start notification was delivered")
+        }
+    }
 }
 
 /// Either announce the recorded build, or — if the user cancelled — delete the

--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::model::{Baseline, Build, BuildDetails, BuildEvent, BuildId, BuildProfile, CrateId};
 
@@ -100,6 +100,7 @@ pub trait BuildRepository: Send + Sync {
 /// - Records each `CompilationFinished` event.
 /// - Finalizes the build on `BuildFinished`.
 /// - Returns the `BuildId` of the recorded build.
+/// - Sends `BuildId` on `started_tx` as soon as the build row is created.
 ///
 /// # Errors
 ///
@@ -108,6 +109,7 @@ pub trait BuildRepository: Send + Sync {
 pub async fn run_persister(
     repo: Arc<dyn BuildRepository>,
     mut rx: mpsc::Receiver<BuildEvent>,
+    started_tx: Option<oneshot::Sender<BuildId>>,
 ) -> anyhow::Result<BuildId> {
     // The first event must be BuildStarted; everything else flows from the
     // BuildId issued here.
@@ -135,6 +137,10 @@ pub async fn run_persister(
             ));
         }
     };
+
+    if let Some(tx) = started_tx {
+        let _ = tx.send(build_id);
+    }
 
     // Drain the rest of the stream. CompilationStarted is informational (only
     // the TUI cares) and intentionally not persisted.
@@ -234,7 +240,7 @@ mod tests {
         tx.send(build_finished(true, 1500)).await.unwrap();
         drop(tx);
 
-        let id = run_persister(repo.clone(), rx).await.unwrap();
+        let id = run_persister(repo.clone(), rx, None).await.unwrap();
         let details = repo.fetch_build(id).await.unwrap().expect("build recorded");
         assert_eq!(details.compilations.len(), 2);
         assert_eq!(details.build.success, Some(true));
@@ -263,7 +269,7 @@ mod tests {
         tx.send(build_finished(true, 100)).await.unwrap();
         drop(tx);
 
-        let id = run_persister(repo.clone(), rx).await.unwrap();
+        let id = run_persister(repo.clone(), rx, None).await.unwrap();
         let details = repo.fetch_build(id).await.unwrap().unwrap();
         assert!(details.compilations.is_empty());
     }
@@ -276,7 +282,7 @@ mod tests {
         tx.send(build_finished(true, 0)).await.unwrap();
         drop(tx);
 
-        let result = run_persister(repo, rx).await;
+        let result = run_persister(repo, rx, None).await;
         assert!(
             result.is_err(),
             "expected error when first event is not BuildStarted, got {:?}",
@@ -293,8 +299,29 @@ mod tests {
         tx.send(build_finished(false, 200)).await.unwrap();
         drop(tx);
 
-        let id = run_persister(repo.clone(), rx).await.unwrap();
+        let id = run_persister(repo.clone(), rx, None).await.unwrap();
         let details = repo.fetch_build(id).await.unwrap().unwrap();
         assert_eq!(details.build.success, Some(false));
+    }
+
+    #[tokio::test]
+    async fn sends_build_id_before_build_finishes() {
+        let (_d, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(16);
+        let (started_tx, started_rx) = oneshot::channel();
+
+        tx.send(build_started()).await.unwrap();
+
+        let persister = tokio::spawn(run_persister(repo.clone(), rx, Some(started_tx)));
+        let id = started_rx.await.expect("build start notification");
+
+        let details = repo.fetch_build(id).await.unwrap().expect("build started");
+        assert_eq!(details.build.success, None);
+
+        tx.send(build_finished(true, 100)).await.unwrap();
+        drop(tx);
+
+        let returned_id = persister.await.unwrap().unwrap();
+        assert_eq!(returned_id, id);
     }
 }


### PR DESCRIPTION
## Summary

Prints the assigned build ID as soon as `record` or `watch` creates the build row, before the build finishes.

## Type of change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] refactor: code change with no behavioural difference
- [ ] test: tests only
- [ ] docs: documentation only
- [ ] chore: build, CI, dependencies, or other miscellany

## Related issue

Closes #66

## Affected modules

- [ ] `model/` (shared types)
- [ ] `cli/`
- [ ] `supervisor/`
- [ ] `parser/`
- [x] `persist/`
- [ ] `diff/`
- [ ] `broker/`
- [ ] `anomaly/`
- [ ] `tui/`
- [x] `main.rs`
- [ ] docs / CI / config

## Tests

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Unit tests added for new behaviour
- [x] Manual test performed (describe below if applicable):

Ran:

```bash
cargo fmt --check
cargo test --all-targets
cargo clippy --all-targets -- -D warnings
```

Manual smoke output from a tiny Cargo project:

```text
Recording build #1...
Build #1 recorded.
```

## Notes for reviewers

`run_persister` now accepts an optional one-shot sender, used by `record` and `watch` to announce the assigned `BuildId` immediately after the build row is created.
