### PR TITLE
chore: v0.1.8 — Ctrl-C now kills cargo, baseline excludes failed builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-05-05
+
+### Fixed
+- `cargo-chronoscope watch` and `record` now actually kill the cargo child process when the user presses `Ctrl-C` (or `q` in the TUI). Previously the `SupervisorHandle` returned by `spawn_build` was discarded, so the outer `CancellationToken` never reached the supervisor and cargo kept compiling silently in the background after the dashboard closed. ([#77](https://github.com/ymw0407/cargo-chronoscope/pull/77), closes [#60](https://github.com/ymw0407/cargo-chronoscope/issues/60))
+- `fetch_baseline` now excludes compilations from failed and unfinalized builds. Pre-fix, the anomaly classifier's mean ± 2σ was contaminated by samples from `success = 0` and never-finalized builds, causing baseline drift and misclassified `slower` / `faster` verdicts on subsequent runs. ([#79](https://github.com/ymw0407/cargo-chronoscope/pull/79))
+
+### Changed
+- TUI: refactored `wait_for_exit_key` so the cancel-handling loop is testable via dependency injection on the key-reading callback, with a regression test that catches re-introductions of the pre-#34 bug. ([#55](https://github.com/ymw0407/cargo-chronoscope/pull/55), closes [#37](https://github.com/ymw0407/cargo-chronoscope/issues/37))
+
 ## [0.1.7] - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-chronoscope"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release after v0.1.7 picking up two real correctness fixes plus the TUI test rework that landed via external contributor PRs.

## Changes since 0.1.7

| PR | Type | Change |
|---|---|---|
| #77 | fix | `SupervisorHandle` now wired through `cmd_record` / `cmd_watch`, so Ctrl-C and TUI `q` actually kill the cargo child instead of leaving it compiling in the background. Closes #60. |
| #79 | fix | `fetch_baseline` SQL now joins `builds` and filters `success = 1`, so failed and unfinalized builds no longer pollute the anomaly-detection mean/stddev. |
| #55 | refactor | TUI `wait_for_exit_key` split into a test-friendly `wait_for_exit_key_with` core, with a regression test that catches re-introductions of the pre-#34 cancel-on-keypress bug. Closes #37. |

Both `fix` items are silent-correctness bugs — the user does not see an error, the tool just behaves incorrectly. Worth a same-week patch ahead of any wider audience reaching the install instructions.

## Cutting the release

After this PR merges:

```bash
git fetch origin main
git checkout main && git pull
git tag v0.1.8
git push origin v0.1.8
```

The release workflow's verify step now passes (Cargo.toml === tag), and the four-target matrix produces the same archives as v0.1.7 plus the bug-fix bins. cargo-binstall + Releases UI surface v0.1.8 automatically.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] test
- [ ] docs
- [x] chore (release prep)

## Tests

- [x] `cargo test` passes (5 unrelated supervisor failures on Windows are pre-existing #57)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Cargo.toml + Cargo.lock version fields are in sync at 0.1.8

## Notes for reviewers

- **CHANGELOG.md** updated with `[0.1.8] - 2026-05-05` section listing all three PRs.
- **No code changes** in this PR; all behavioural deltas are already on main from #55 / #77 / #79.
- v0.1.7 was tagged less than a day before v0.1.8 — that's intentional given the silent-correctness nature of #77 and #79. Future "release theme" cohesion can resume from v0.2.x.