### PR TITLE
chore: v0.1.9 — consolidate crate + action under a single vX.Y.Z tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-05-05
+
+### Changed
+- Release tagging consolidated: `vX.Y.Z` is now the single canonical tag for both the crate and the GitHub Action. Each release commit ships Cargo.toml + action.yml + examples in lockstep, so the `version` input default in `action.yml` always matches the crate version under the same `vX.Y.Z` tag. This makes the GitHub Marketplace's auto-suggested `uses: ymw0407/cargo-chronoscope@v0.1.9` reference do the right thing — previously it pointed at a commit where `action.yml` defaulted to an older crate version, silently installing a stale binary.
+- `action-v1` (moving) and `action-v1.0.x` (immutable) tags are kept working for existing users but marked legacy in the README. New workflows should pin to `@vX.Y.Z`. The `action-v1.0.x` immutable namespace is frozen at `action-v1.0.4` (= 0.1.8 era); future immutables are just the crate `vX.Y.Z` tag.
+
 ## [0.1.8] - 2026-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-chronoscope"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chronoscope"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Cargo build performance observer — record, diff, and watch your Rust builds"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ jobs:
 
       - uses: ymw0407/cargo-chronoscope@action-v1
         with:
-          version: '0.1.8'
+          version: '0.1.9'
           cargo-args: '--release'
           baseline-ref: 'main'
           comment: 'false'           # let the companion workflow post
@@ -275,7 +275,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: ymw0407/cargo-chronoscope@action-v1
         with:
-          version: '0.1.8'
+          version: '0.1.9'
           comment: 'true'           # action posts the comment itself
 ```
 
@@ -283,19 +283,17 @@ This will silently skip the comment step on any forked-PR run.
 
 ### Tags
 
-Release tags follow two namespaces:
-
 | Tag | Purpose | Example pin |
 |---|---|---|
-| `vX.Y.Z`         | Binary release on crates.io. Used by `cargo install`. | `cargo install cargo-chronoscope --version 0.1.8` |
-| `action-vN`      | Moving major tag for the GitHub Action — points at the latest backward-compatible release. | `uses: ymw0407/cargo-chronoscope@action-v1` |
-| `action-vN.M.P`  | Immutable point release for the action.              | `uses: ymw0407/cargo-chronoscope@action-v1.0.4` |
+| `vX.Y.Z`         | The canonical tag — same commit ships the crate to crates.io and the action to the Marketplace. Use it for both `cargo install` and `uses:`. | `cargo install cargo-chronoscope --version 0.1.9` / `uses: ymw0407/cargo-chronoscope@v0.1.9` |
+| `action-vN`      | _Legacy._ Moving major tag for the GitHub Action that auto-tracks the latest crate release. Kept working for existing users; new workflows should pin to `@vX.Y.Z` directly. | `uses: ymw0407/cargo-chronoscope@action-v1` |
+| `action-vN.M.P`  | _Legacy / frozen._ Immutable action tags from the dual-namespace era (≤ `action-v1.0.4` / crate 0.1.8). New immutables are just the crate `vX.Y.Z` tag — no separate action-v* point releases going forward. | `uses: ymw0407/cargo-chronoscope@action-v1.0.4` |
 
 ### Action inputs
 
 | Input              | Default            | Description |
 |--------------------|--------------------|-------------|
-| `version`          | `0.1.8`            | crate version installed via `cargo install`. Use a concrete version for reproducibility, or `latest`. |
+| `version`          | `0.1.9`            | crate version installed via `cargo install`. Use a concrete version for reproducibility, or `latest`. |
 | `cargo-args`       | `--release`        | Forwarded verbatim to `cargo build`. |
 | `baseline-ref`     | `main`             | Branch whose cached DB is the baseline. Only pushes to this ref update the cache. |
 | `cache-key-prefix` | `chronoscope-db`   | Prefix for the GitHub Actions cache key. |

--- a/action.yml
+++ b/action.yml
@@ -38,11 +38,11 @@ inputs:
   version:
     description: >-
       cargo-chronoscope version to install. Pinning a concrete version
-      (e.g. `0.1.8`) gives reproducible runs; `latest` always pulls the
+      (e.g. `0.1.9`) gives reproducible runs; `latest` always pulls the
       newest published crate. Defaults to the current recommended action
       version.
     required: false
-    default: '0.1.8'
+    default: '0.1.9'
   cargo-args:
     description: >-
       Arguments forwarded verbatim to `cargo build` via

--- a/examples/ci/build-perf.yml
+++ b/examples/ci/build-perf.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           # cargo-chronoscope binary version pulled from crates.io. Pin a
           # concrete version for reproducibility, or use `latest`.
-          version: '0.1.8'
+          version: '0.1.9'
           # Forwarded to `cargo build`. Default is --release; pass an empty
           # string for a debug build.
           cargo-args: '--release'


### PR DESCRIPTION
## Summary

Adopts the **single-namespace** release convention going forward — every release commit ships Cargo.toml + action.yml + examples together under the `vX.Y.Z` tag, so the GitHub Marketplace's auto-suggested `uses: ymw0407/cargo-chronoscope@v0.1.9` reference now Just Works.

No code changes; this is purely the convention switch + first release that follows it.

## Why now

The 0.1.8 release exposed a tagging-convention mismatch:

- Marketplace promotes `uses: ymw0407/cargo-chronoscope@v0.1.8` (latest tag).
- But `v0.1.8` tag pointed at the Cargo.toml-bump commit, which still had `action.yml` default `'0.1.6'`.
- Result: a user following Marketplace's recommended snippet silently installed 0.1.6 — missing the very Ctrl-C fix (#77) and baseline-pollution fix (#79) that 0.1.8 was cut for.

Going forward, action.yml's `version` default tracks the crate version inside the same release commit. No more silent staleness.

## What changes

| File | Change |
|---|---|
| `Cargo.toml` / `Cargo.lock` | 0.1.8 → 0.1.9 |
| `action.yml` | `version` default `'0.1.8'` → `'0.1.9'` + description example |
| `examples/ci/build-perf.yml` | pinned `version: '0.1.9'` |
| `README.md` | install / example workflows / inputs table at 0.1.9; Tags section rewritten to mark `action-v*` as legacy |
| `CHANGELOG.md` | `[0.1.9]` section explaining the consolidation |

## Tag namespace going forward

| Tag | Status |
|---|---|
| `vX.Y.Z` | **Canonical.** Each release commit; ships crate + action together. |
| `action-v1` | _Legacy moving._ Kept retag-aligned with each crate release for back-compat. |
| `action-v1.0.x` | _Frozen at action-v1.0.4_ (= 0.1.8 era). No new action-v* immutables; future immutables are the crate `vX.Y.Z` tag itself. |

## Cutting the release

After this PR merges:

```bash
git fetch origin main
git checkout main && git pull
git tag v0.1.9
git push origin v0.1.9

# legacy support: keep @action-v1 auto-tracking the latest crate release
git tag -f action-v1 origin/main
git push origin action-v1 --force
# (no new action-v1.0.5 — that namespace is frozen)
```

Release workflow's verify step passes (Cargo.toml === tag), 4-target matrix produces archives at v0.1.9, crates.io publishes 0.1.9. Marketplace auto-promotes `@v0.1.9` and the bundled `action.yml` correctly installs 0.1.9 with no `version:` override needed.

## Type of change

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] test
- [ ] docs
- [x] chore (release / convention change)

## Tests

- [ ] `cargo test`
- [ ] `cargo clippy -- -D warnings`
- [ ] Unit tests added
- [x] Manual: Cargo.toml, Cargo.lock, action.yml, examples, README all reference 0.1.9 consistently.

## Notes for reviewers

- This is a **convention change** more than a code change. The diff is small but the semantic shift is durable: from now on, every Cargo.toml bump is also an action.yml bump.
- I considered force-rebasing the `v0.1.8` tag to include the action default bump (would have made `@v0.1.8` Just Work retroactively), but mutating a published release tag is bad practice. A clean v0.1.9 is the right resolution.
- The fork-PR sticky comment workflow on this PR will be the first end-to-end test of the new release convention before publication. If it goes green, we're good to tag.